### PR TITLE
VSCode - Name wording: Tools instead of Support

### DIFF
--- a/vscode-extensions/vscode-spring-boot/package.json
+++ b/vscode-extensions/vscode-spring-boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-spring-boot",
-  "displayName": "Spring Boot Support",
+  "displayName": "Spring Boot Tools",
   "description": "Provides validation and content assist for Spring Boot `application.properties`, `application.yml` properties files. As well as Boot-specific support for `.java` files.",
   "icon": "spring-boot-logo.png",
   "version": "0.1.5",


### PR DESCRIPTION
Of course, it is for authors to name their creation.

Nevertheless, there are now 2 VSCode extension with name "Spring Boot Support".  
And also current published version is the same version number as previous obsolete: 0.1.4  
That make confusion.

Also Tools is used in https://spring.io/tools4
and has been unique word on Eclipse marketplace.