### PR TITLE
No boot-hint gutter icon for Atom

### DIFF
--- a/atom-extensions/atom-spring-boot/lib/boot-sts-adapter.ts
+++ b/atom-extensions/atom-spring-boot/lib/boot-sts-adapter.ts
@@ -27,14 +27,14 @@ export class BootStsAdapter extends StsAdapter {
         if (Array.isArray(ranges)) {
             ranges.forEach(range => this.createHintMarker(editor, range));
         }
-        const gutter = editor.gutterWithName(BOOT_HINT_GUTTER_NAME);
-        if (gutter) {
-            if (!ranges || !ranges.length) {
-                gutter.hide();
-            } else if (!gutter.isVisible()) {
-                gutter.show();
-            }
-        }
+        // const gutter = editor.gutterWithName(BOOT_HINT_GUTTER_NAME);
+        // if (gutter) {
+        //     if (!ranges || !ranges.length) {
+        //         gutter.hide();
+        //     } else if (!gutter.isVisible()) {
+        //         gutter.show();
+        //     }
+        // }
     }
 
     private createHintMarker(editor: TextEditor, range: Range) {
@@ -45,16 +45,16 @@ export class BootStsAdapter extends StsAdapter {
         editor.decorateMarker(marker, DECORATION_OPTIONS);
 
         // Marker in the diagnostic gutter
-        let gutter = editor.gutterWithName(BOOT_HINT_GUTTER_NAME);
-        if (!gutter) {
-            gutter = editor.addGutter({
-                name: BOOT_HINT_GUTTER_NAME,
-                visible: false,
-            });
-        }
-        const iconElement = document.createElement('span');
-        iconElement.setAttribute('class', 'gutter-boot-hint');
-        gutter.decorateMarker(marker, {item: iconElement});
+        // let gutter = editor.gutterWithName(BOOT_HINT_GUTTER_NAME);
+        // if (!gutter) {
+        //     gutter = editor.addGutter({
+        //         name: BOOT_HINT_GUTTER_NAME,
+        //         visible: false,
+        //     });
+        // }
+        // const iconElement = document.createElement('span');
+        // iconElement.setAttribute('class', 'gutter-boot-hint');
+        // gutter.decorateMarker(marker, {item: iconElement});
     }
 
 }

--- a/atom-extensions/atom-spring-boot/properties.json
+++ b/atom-extensions/atom-spring-boot/properties.json
@@ -1,3 +1,3 @@
 {
-    "jarUrl": "https://s3-us-west-1.amazonaws.com/s3-test.spring.io/sts4/fatjars/snapshots/spring-boot-language-server-0.6.0-201808212257.jar"
+    "jarUrl": "https://s3.amazonaws.com/dist.springsource.com/release/STS4/fatjars/spring-boot-language-server-0.7.0-201809100923.jar"
 }


### PR DESCRIPTION
Atom still displays boot-hint icon in the gutter.
Comment it out.