### PR TITLE
PT #160634135: Show symbols in workspace by default

### DIFF
--- a/eclipse-language-servers/org.springframework.tooling.ls.eclipse.gotosymbol/src/org/springframework/tooling/ls/eclipse/gotosymbol/handlers/GotoSymbolHandler.java
+++ b/eclipse-language-servers/org.springframework.tooling.ls.eclipse.gotosymbol/src/org/springframework/tooling/ls/eclipse/gotosymbol/handlers/GotoSymbolHandler.java
@@ -64,7 +64,7 @@ public class GotoSymbolHandler extends AbstractHandler {
 				final Shell shell = HandlerUtil.getActiveShell(event);
 				final ITextEditor textEditor = (ITextEditor) part;
 				
-				GotoSymbolDialogModel model = new GotoSymbolDialogModel(getKeybindings(event), InFileSymbolsProvider.createFor(textEditor), InWorkspaceSymbolsProvider.createFor(event))
+				GotoSymbolDialogModel model = new GotoSymbolDialogModel(getKeybindings(event), InWorkspaceSymbolsProvider.createFor(event), InFileSymbolsProvider.createFor(textEditor))
 				.setOkHandler(symbolInformation -> {
 					if (symbolInformation!=null) {
 						Location location = symbolInformation.getLocation();


### PR DESCRIPTION
Got to Symbol in Workspace shows by default. Cmd-6 or Ctrl-6 to toggle between workspace and file symbols