### PR TITLE
Add supported get params for S3 Resource

### DIFF
--- a/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
+++ b/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
@@ -556,7 +556,8 @@ public class PipelineYmlSchema implements YamlSchema {
 			source.requireOneOf("regexp", "versioned_file");
 
 			AbstractType get = f.ybean("S3GetParams");
-			//Note: S3GetParams intentionally has no properties since no params are expected according to the docs.
+			addProp(get, "unpack", t_boolean);
+			addProp(get, "skip_download", t_boolean);
 
 			AbstractType put = f.ybean("S3PutParams");
 			addProp(put, "file", t_ne_string).isPrimary(true);


### PR DESCRIPTION
The `s3` Concourse resource now supports multiple `get` parameters,
including:
* `unpack`: If the downloaded file is a zip file or tarball (with or
without compression), the resource will unpack it.
* `skip_download`: It will skip actually downloading the file and
only download metadata instead.

The unpack parameter is now used extensively, because since Concourse
3.7, you can use s3 as a storage location for rootfs images for tasks.
That makes it very enticing to have in the schema.

Thanks for considering this PR!