### PR TITLE
URL Cleanup

### DIFF
--- a/eclipse-distribution/org.springframework.boot.ide.branding.feature/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.branding.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-distribution/org.springframework.boot.ide.branding/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.branding/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.product.e47/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.product.e47/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.repository.e47/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.repository.e47/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/pom.xml
+++ b/eclipse-distribution/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.boot.ide</groupId>
@@ -22,7 +22,7 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -111,47 +111,47 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/oxygen/</url>
+					<url>https://download.eclipse.org/staging/oxygen/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/</url>
 				</repository>
 				<repository>
 					<id>maven-extras-mirror</id>
 					<layout>p2</layout>
-					<url>http://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
+					<url>https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
 				</repository>
 				<repository>
 					<id>maven-egit</id>
 					<layout>p2</layout>
-					<url>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
+					<url>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
 				</repository>
 				<repository>
 					<id>maven-wro4j</id>
 					<layout>p2</layout>
-					<url>http://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
+					<url>https://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
 				</repository>
 				<repository>
 					<id>maven-devtools</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/release/TOOLS/mavendevtools/</url>
+					<url>https://dist.springsource.com/release/TOOLS/mavendevtools/</url>
 				</repository>
 				<repository>
 					<id>maven-dependency-support</id>
 					<layout>p2</layout>
-					<url>http://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
+					<url>https://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
 				</repository>
 				<repository>
 					<id>ansi-console</id>
 					<layout>p2</layout>
-					<url>http://www.mihai-nita.net/eclipse</url>
+					<url>https://www.mihai-nita.net/eclipse</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -172,8 +172,8 @@
 					-Dhttps.proxyHost=proxy.eng.vmware.com -Dhttps.proxyPort=3128 ${test.osvmargs}</test.vmargs> -->
 				<p2.qualifier>CI-B${bamboo.buildNumber}</p2.qualifier>
 				<p2.replaceQualifier>true</p2.replaceQualifier>
-				<!-- <http_proxy>http://proxy.eng.vmware.com:3128</http_proxy> -->
-				<!-- <https_proxy>http://proxy.eng.vmware.com:3128</https_proxy> -->
+				<!-- <http_proxy>https://proxy.eng.vmware.com:3128</http_proxy> -->
+				<!-- <https_proxy>https://proxy.eng.vmware.com:3128</https_proxy> -->
 			</properties>
 		</profile>
 
@@ -191,22 +191,22 @@
 		<repository>
 			<id>spring-boot-language-servers</id>
 			<layout>p2</layout>
-			<url>http://dist.springsource.com/${dist.type}/TOOLS/sts4-language-servers/${dist.springboot-language-servers-pathpostfix}</url>
+			<url>https://dist.springsource.com/${dist.type}/TOOLS/sts4-language-servers/${dist.springboot-language-servers-pathpostfix}</url>
 		</repository>
 		<repository>
 			<id>springide</id>
 			<layout>p2</layout>
-			<url>http://dist.springframework.org/${dist.type}/IDE/${dist.springide-pathpostfix}</url>
+			<url>https://dist.springframework.org/${dist.type}/IDE/${dist.springide-pathpostfix}</url>
 		</repository>
 		<repository>
 			<id>eclipse-integration-commons</id>
 			<layout>p2</layout>
-			<url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}</url>
+			<url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}</url>
 		</repository>
 		<repository>
 			<id>egit-github</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/egit/github/updates</url>
+			<url>https://download.eclipse.org/egit/github/updates</url>
 		</repository>
 	</repositories>
 
@@ -219,12 +219,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>sonatype.snapshots</id>

--- a/eclipse-extensions/org.springframework.boot.ide.main.feature/pom.xml
+++ b/eclipse-extensions/org.springframework.boot.ide.main.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.boot.ide.cloudfoundry.server.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.boot.ide.cloudfoundry.server.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.boot.ide.cloudfoundry.server/pom.xml
+++ b/eclipse-language-servers/org.springframework.boot.ide.cloudfoundry.server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.boot.ide.properties.servers.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.boot.ide.properties.servers.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.boot.ide.properties.servers/pom.xml
+++ b/eclipse-language-servers/org.springframework.boot.ide.properties.servers/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.boot.ide.servers.repository/pom.xml
+++ b/eclipse-language-servers/org.springframework.boot.ide.servers.repository/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>repository</artifactId>
 

--- a/eclipse-language-servers/pom.xml
+++ b/eclipse-language-servers/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.boot.ide</groupId>
@@ -22,7 +22,7 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -69,22 +69,22 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/oxygen/</url>
+					<url>https://download.eclipse.org/staging/oxygen/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/</url>
 				</repository>
 				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository>
 				<repository>
 					<id>tm4e</id>
@@ -106,8 +106,8 @@
 					-Dhttps.proxyHost=proxy.eng.vmware.com -Dhttps.proxyPort=3128 ${test.osvmargs}</test.vmargs> -->
 				<p2.qualifier>CI-B${bamboo.buildNumber}</p2.qualifier>
 				<p2.replaceQualifier>true</p2.replaceQualifier>
-				<!-- <http_proxy>http://proxy.eng.vmware.com:3128</http_proxy> -->
-				<!-- <https_proxy>http://proxy.eng.vmware.com:3128</https_proxy> -->
+				<!-- <http_proxy>https://proxy.eng.vmware.com:3128</http_proxy> -->
+				<!-- <https_proxy>https://proxy.eng.vmware.com:3128</https_proxy> -->
 			</properties>
 		</profile>
 
@@ -130,12 +130,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>sonatype.snapshots</id>

--- a/vscode-extensions/commons/commons-cf/pom.xml
+++ b/vscode-extensions/commons/commons-cf/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-cf</artifactId>
 	<name>commons-cf</name>

--- a/vscode-extensions/commons/commons-java/pom.xml
+++ b/vscode-extensions/commons/commons-java/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-java</artifactId>
 	<name>commons-java</name>

--- a/vscode-extensions/commons/commons-language-server/pom.xml
+++ b/vscode-extensions/commons/commons-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-language-server</artifactId>
 	<name>commons-language-server</name>

--- a/vscode-extensions/commons/commons-maven/pom.xml
+++ b/vscode-extensions/commons/commons-maven/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>commons-maven</artifactId>

--- a/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw.cmd
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/pom.xml
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw.cmd
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/pom.xml
+++ b/vscode-extensions/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework</groupId>

--- a/vscode-extensions/commons/commons-util/pom.xml
+++ b/vscode-extensions/commons/commons-util/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-util</artifactId>
 	<name>commons-util</name>

--- a/vscode-extensions/commons/commons-yaml/pom.xml
+++ b/vscode-extensions/commons/commons-yaml/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-yaml</artifactId>
 	<name>commons-yaml</name>

--- a/vscode-extensions/commons/java-properties/pom.xml
+++ b/vscode-extensions/commons/java-properties/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>java-properties</artifactId>
 	<description>Java Properties parser, AST and utilities</description>

--- a/vscode-extensions/commons/language-server-test-harness/pom.xml
+++ b/vscode-extensions/commons/language-server-test-harness/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>language-server-test-harness</artifactId>
 	<name>language-server-test-harness</name>

--- a/vscode-extensions/commons/pom.xml
+++ b/vscode-extensions/commons/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ide.vscode</groupId>
@@ -48,7 +48,7 @@
 	    <repository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 		</repository>
 	</repositories>
 

--- a/vscode-extensions/mvnw
+++ b/vscode-extensions/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/mvnw.cmd
+++ b/vscode-extensions/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/pom.xml
+++ b/vscode-extensions/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ide.vscode</groupId>

--- a/vscode-extensions/vscode-boot-java/pom.xml
+++ b/vscode-extensions/vscode-boot-java/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>vscode-boot-java</artifactId>

--- a/vscode-extensions/vscode-boot-properties/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>vscode-boot-properties</artifactId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>
@@ -21,7 +21,7 @@
 	<repositories>
 	  <repository>
 	    <id>libs-snapshot</id>
-	    <url>http://repo.spring.io/libs-snapshot</url>
+	    <url>https://repo.spring.io/libs-snapshot</url>
 	    <snapshots>
 	      <enabled>true</enabled>
 	    </snapshots>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/boot-1.3.3-sts-4335/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/custom-properties-boot-project/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/enums-boot-1.3.2-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw.cmd
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/pom.xml
+++ b/vscode-extensions/vscode-boot-properties/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/vscode-extensions/vscode-concourse/pom.xml
+++ b/vscode-extensions/vscode-concourse/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>vscode-concourse</artifactId>

--- a/vscode-extensions/vscode-manifest-yaml/pom.xml
+++ b/vscode-extensions/vscode-manifest-yaml/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>vscode-manifest-yaml</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://s3-test.spring.io/sts4/vscode-extensions/ (403) with 5 occurrences could not be migrated:  
   ([https](https://s3-test.spring.io/sts4/vscode-extensions/) result SSLHandshakeException).
* http://oss.opensagres.fr/textmate/1.0.0-SNAPSHOT/ (404) with 1 occurrences could not be migrated:  
   ([https](https://oss.opensagres.fr/textmate/1.0.0-SNAPSHOT/) result SSLHandshakeException).
* http://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/maven-repository/ (404) with 1 occurrences could not be migrated:  
   ([https](https://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/maven-repository/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://proxy.eng.vmware.com:3128 (UnknownHostException) with 4 occurrences migrated to:  
  https://proxy.eng.vmware.com:3128 ([https](https://proxy.eng.vmware.com:3128) result UnknownHostException).
* http://dist.springsource.com/ (403) with 2 occurrences migrated to:  
  https://dist.springsource.com/ ([https](https://dist.springsource.com/) result 403).
* http://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/ (403) with 1 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/ ([https](https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/) result 403).
* http://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/ (404) with 2 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/S20161205183421/repository/) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 2 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dist.springframework.org/ with 1 occurrences migrated to:  
  https://dist.springframework.org/ ([https](https://dist.springframework.org/) result 200).
* http://dist.springsource.com/release/TOOLS/mavendevtools/ with 1 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/mavendevtools/ ([https](https://dist.springsource.com/release/TOOLS/mavendevtools/) result 200).
* http://download.eclipse.org/lsp4e/snapshots/ with 1 occurrences migrated to:  
  https://download.eclipse.org/lsp4e/snapshots/ ([https](https://download.eclipse.org/lsp4e/snapshots/) result 200).
* http://download.eclipse.org/releases/oxygen/ with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen/ ([https](https://download.eclipse.org/releases/oxygen/) result 200).
* http://download.eclipse.org/staging/oxygen/ with 2 occurrences migrated to:  
  https://download.eclipse.org/staging/oxygen/ ([https](https://download.eclipse.org/staging/oxygen/) result 200).
* http://download.jboss.org/jbosstools/updates/m2e-wro4j/ with 1 occurrences migrated to:  
  https://download.jboss.org/jbosstools/updates/m2e-wro4j/ ([https](https://download.jboss.org/jbosstools/updates/m2e-wro4j/) result 200).
* http://ianbrandt.github.io/m2e-maven-dependency-plugin/ with 1 occurrences migrated to:  
  https://ianbrandt.github.io/m2e-maven-dependency-plugin/ ([https](https://ianbrandt.github.io/m2e-maven-dependency-plugin/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 21 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/ with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/ ([https](https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 26 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.eclipse.org/legal/epl-v10.html with 2 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://download.eclipse.org/egit/github/updates with 1 occurrences migrated to:  
  https://download.eclipse.org/egit/github/updates ([https](https://download.eclipse.org/egit/github/updates) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 17 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.mihai-nita.net/eclipse with 1 occurrences migrated to:  
  https://www.mihai-nita.net/eclipse ([https](https://www.mihai-nita.net/eclipse) result 301).
* http://maven.springframework.org/release with 2 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 76 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 38 occurrences