### PR TITLE
URL Cleanup

### DIFF
--- a/eclipse-distribution/org.springframework.boot.ide.branding.feature/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.branding.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-distribution/org.springframework.boot.ide.branding/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.branding/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.product.e47/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.product.e47/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.product.e48/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.product.e48/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.repository.e47/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.repository.e47/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/org.springframework.boot.ide.repository.e48/pom.xml
+++ b/eclipse-distribution/org.springframework.boot.ide.repository.e48/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-distribution/pom.xml
+++ b/eclipse-distribution/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.boot.ide</groupId>
@@ -22,7 +22,7 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -55,9 +55,9 @@
 		<dist.pathpostfix>nightly</dist.pathpostfix>
 		<dist.path>${dist.type}/${dist.key}/${dist.project}/${dist.pathpostfix}</dist.path>
 		
-		<eclipsecommons-p2-repo>http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly</eclipsecommons-p2-repo>
-		<springide-p2-repo>http://dist.springframework.org/snapshot/IDE/nightly</springide-p2-repo>
-		<sts4-language-servers-p2-repo>http://dist.springsource.com/${dist.type}/TOOLS/sts4-language-server-integrations/${sts4-language-servers-version}</sts4-language-servers-p2-repo>
+		<eclipsecommons-p2-repo>https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly</eclipsecommons-p2-repo>
+		<springide-p2-repo>https://dist.springframework.org/snapshot/IDE/nightly</springide-p2-repo>
+		<sts4-language-servers-p2-repo>https://dist.springsource.com/${dist.type}/TOOLS/sts4-language-server-integrations/${sts4-language-servers-version}</sts4-language-servers-p2-repo>
 
 		<tycho-version>0.26.0</tycho-version>
 		<encoding>UTF-8</encoding>
@@ -116,82 +116,82 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 <!--				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/oxygen/</url>
+					<url>https://download.eclipse.org/staging/oxygen/</url>
 				</repository> -->
 <!--				<repository>
 					<id>platform-m-build</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.7-M-builds</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.7-M-builds</url>
 				</repository> -->
 				<repository>
 					<id>latest-m2e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/m2e/releases</url>
+					<url>https://download.eclipse.org/technology/m2e/releases</url>
 				</repository>
 				<repository>
 					<id>latest-m2e-milestones</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/m2e/milestones/1.8/</url>
+					<url>https://download.eclipse.org/technology/m2e/milestones/1.8/</url>
 				</repository>
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/</url>
 				</repository>
 				<repository>
 					<id>latest-buildship-release</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e47/releases/2.x</url>
+					<url>https://download.eclipse.org/buildship/updates/e47/releases/2.x</url>
 				</repository>
 				<repository>
 					<id>maven-extras-mirror</id>
 					<layout>p2</layout>
-					<url>http://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
+					<url>https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
 				</repository>
 				<repository>
 					<id>maven-egit</id>
 					<layout>p2</layout>
-					<url>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
+					<url>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
 				</repository>
 				<repository>
 					<id>maven-wro4j</id>
 					<layout>p2</layout>
-					<url>http://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
+					<url>https://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
 				</repository>
 				<repository>
 					<id>maven-devtools</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/release/TOOLS/mavendevtools/</url>
+					<url>https://dist.springsource.com/release/TOOLS/mavendevtools/</url>
 				</repository>
 				<repository>
 					<id>maven-dependency-support</id>
 					<layout>p2</layout>
-					<url>http://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
+					<url>https://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
 				</repository>
 				<repository>
 					<id>ansi-console</id>
 					<layout>p2</layout>
-					<url>http://www.mihai-nita.net/eclipse</url>
+					<url>https://www.mihai-nita.net/eclipse</url>
 				</repository>
 				<repository>
 					<id>xtext-base</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/modeling/tmf/xtext/updates/milestones/</url>
+					<url>https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/</url>
 				</repository>
 <!--				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository> -->
 				<repository>
 					<id>lsp4e-050-stream</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/0.5.0milestone/</url>
+					<url>https://download.eclipse.org/lsp4e/0.5.0milestone/</url>
 				</repository>
 			</repositories>
 			<modules>
@@ -215,82 +215,82 @@
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/photon/</url>
+					<url>https://download.eclipse.org/releases/photon/</url>
 				</repository>
 <!--				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/photon/</url>
+					<url>https://download.eclipse.org/staging/photon/</url>
 				</repository> -->
 				<repository>
 					<id>platform-i-builds</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8-I-builds/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8-I-builds/</url>
 				</repository>
 <!--				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/</url>
 				</repository> -->
 				<repository>
 					<id>orbit-i-builds</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/latest-I/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/latest-I/</url>
 				</repository>
 				<repository>
 					<id>latest-m2e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/m2e/releases</url>
+					<url>https://download.eclipse.org/technology/m2e/releases</url>
 				</repository>
 				<repository>
 					<id>latest-m2e-milestones</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/technology/m2e/milestones/1.8/</url>
+					<url>https://download.eclipse.org/technology/m2e/milestones/1.8/</url>
 				</repository>
 				<repository>
 					<id>latest-buildship-release</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/buildship/updates/e47/releases/2.x</url>
+					<url>https://download.eclipse.org/buildship/updates/e47/releases/2.x</url>
 				</repository>
 				<repository>
 					<id>maven-extras-mirror</id>
 					<layout>p2</layout>
-					<url>http://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
+					<url>https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/</url>
 				</repository>
 				<repository>
 					<id>maven-egit</id>
 					<layout>p2</layout>
-					<url>http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
+					<url>https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/</url>
 				</repository>
 				<repository>
 					<id>maven-wro4j</id>
 					<layout>p2</layout>
-					<url>http://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
+					<url>https://download.jboss.org/jbosstools/updates/m2e-wro4j/</url>
 				</repository>
 				<repository>
 					<id>maven-devtools</id>
 					<layout>p2</layout>
-					<url>http://dist.springsource.com/release/TOOLS/mavendevtools/</url>
+					<url>https://dist.springsource.com/release/TOOLS/mavendevtools/</url>
 				</repository>
 				<repository>
 					<id>maven-dependency-support</id>
 					<layout>p2</layout>
-					<url>http://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
+					<url>https://ianbrandt.github.io/m2e-maven-dependency-plugin/</url>
 				</repository>
 				<repository>
 					<id>ansi-console</id>
 					<layout>p2</layout>
-					<url>http://www.mihai-nita.net/eclipse</url>
+					<url>https://www.mihai-nita.net/eclipse</url>
 				</repository>
 				<repository>
 					<id>xtext-base</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/modeling/tmf/xtext/updates/milestones/</url>
+					<url>https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/</url>
 				</repository>
 				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository>
 				<repository>
 					<id>lsp4j</id>
@@ -316,8 +316,8 @@
 					-Dhttps.proxyHost=proxy.eng.vmware.com -Dhttps.proxyPort=3128 ${test.osvmargs}</test.vmargs> -->
 				<p2.qualifier>CI-B${bamboo.buildNumber}</p2.qualifier>
 				<p2.replaceQualifier>true</p2.replaceQualifier>
-				<!-- <http_proxy>http://proxy.eng.vmware.com:3128</http_proxy> -->
-				<!-- <https_proxy>http://proxy.eng.vmware.com:3128</https_proxy> -->
+				<!-- <http_proxy>https://proxy.eng.vmware.com:3128</http_proxy> -->
+				<!-- <https_proxy>https://proxy.eng.vmware.com:3128</https_proxy> -->
 			</properties>
 		</profile>
 
@@ -350,7 +350,7 @@
 		<repository>
 			<id>egit-github</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/egit/github/updates</url>
+			<url>https://download.eclipse.org/egit/github/updates</url>
 		</repository>
 	</repositories>
 
@@ -363,12 +363,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>sonatype.snapshots</id>

--- a/eclipse-extensions/org.springframework.boot.ide.main.feature/pom.xml
+++ b/eclipse-extensions/org.springframework.boot.ide.main.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.boot.java.ls.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.boot.java.ls.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.boot.java.ls/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.boot.java.ls/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.tooling.bosh.ls.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.bosh.ls.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.bosh.ls/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.bosh.ls/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.integration.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.integration.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.integration/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls.integration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.cloudfoundry.manifest.ls/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.tooling.concourse.ls.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.concourse.ls.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.concourse.ls/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.concourse.ls/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/org.springframework.tooling.ls.eclipse.commons/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.ls.eclipse.commons/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.ls.eclipse.gotosymbol/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.ls.eclipse.gotosymbol/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.ls.integration.repository/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.ls.integration.repository/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.springframework.tooling.ls.integration.repository</artifactId>
 

--- a/eclipse-language-servers/org.springframework.tooling.ls.repository/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.ls.repository/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.springframework.tooling.ls.repository</artifactId>
 

--- a/eclipse-language-servers/org.springframework.tooling.properties.ls.feature/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.properties.ls.feature/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot.ide</groupId>

--- a/eclipse-language-servers/org.springframework.tooling.properties.ls/pom.xml
+++ b/eclipse-language-servers/org.springframework.tooling.properties.ls/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/eclipse-language-servers/pom.xml
+++ b/eclipse-language-servers/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.boot.ide</groupId>
@@ -22,7 +22,7 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v10.html</url>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
 
@@ -118,17 +118,17 @@
 				<repository>
 					<id>oxygen</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/oxygen/</url>
+					<url>https://download.eclipse.org/releases/oxygen/</url>
 				</repository>
 <!--				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/oxygen/</url>
+					<url>https://download.eclipse.org/staging/oxygen/</url>
 				</repository> -->
 				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/</url>
 				</repository>
 				<repository>
 					<id>lsp4j-snapshots</id>
@@ -138,22 +138,22 @@
 				<repository>
 					<id>e-i-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springframework.org/snapshot/IDE/nightly</url>
+					<url>https://dist.springframework.org/snapshot/IDE/nightly</url>
 				</repository>
 <!--				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository> -->
 				<repository>
 					<id>lsp4e-050-stream</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/0.5.0milestone/</url>
+					<url>https://download.eclipse.org/lsp4e/0.5.0milestone/</url>
 				</repository>
 				<repository>
 					<id>tm4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tm4e/snapshots/</url>
+					<url>https://download.eclipse.org/tm4e/snapshots/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -173,27 +173,27 @@
 				<repository>
 					<id>photon</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/releases/photon/</url>
+					<url>https://download.eclipse.org/releases/photon/</url>
 				</repository>
 <!--				<repository>
 					<id>staging</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/staging/photon/</url>
+					<url>https://download.eclipse.org/staging/photon/</url>
 				</repository> -->
 				<repository>
 					<id>platform-i-builds</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/eclipse/updates/4.8-I-builds/</url>
+					<url>https://download.eclipse.org/eclipse/updates/4.8-I-builds/</url>
 				</repository>
 <!--				<repository>
 					<id>orbit</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/</url>
 				</repository> -->
 				<repository>
 					<id>orbit-i-builds</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tools/orbit/downloads/latest-I/</url>
+					<url>https://download.eclipse.org/tools/orbit/downloads/latest-I/</url>
 				</repository>
 				<repository>
 					<id>lsp4j-snapshots</id>
@@ -203,17 +203,17 @@
 				<repository>
 					<id>e-i-commons</id>
 					<layout>p2</layout>
-					<url>http://dist.springframework.org/snapshot/IDE/nightly</url>
+					<url>https://dist.springframework.org/snapshot/IDE/nightly</url>
 				</repository>
 				<repository>
 					<id>lsp4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/lsp4e/snapshots/</url>
+					<url>https://download.eclipse.org/lsp4e/snapshots/</url>
 				</repository>
 				<repository>
 					<id>tm4e</id>
 					<layout>p2</layout>
-					<url>http://download.eclipse.org/tm4e/snapshots/</url>
+					<url>https://download.eclipse.org/tm4e/snapshots/</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -230,8 +230,8 @@
 					-Dhttps.proxyHost=proxy.eng.vmware.com -Dhttps.proxyPort=3128 ${test.osvmargs}</test.vmargs> -->
 				<p2.qualifier>CI-B${bamboo.buildNumber}</p2.qualifier>
 				<p2.replaceQualifier>true</p2.replaceQualifier>
-				<!-- <http_proxy>http://proxy.eng.vmware.com:3128</http_proxy> -->
-				<!-- <https_proxy>http://proxy.eng.vmware.com:3128</https_proxy> -->
+				<!-- <http_proxy>https://proxy.eng.vmware.com:3128</http_proxy> -->
+				<!-- <https_proxy>https://proxy.eng.vmware.com:3128</https_proxy> -->
 			</properties>
 		</profile>
 
@@ -254,12 +254,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>sonatype.snapshots</id>

--- a/headless-services/boot-java-language-server/pom.xml
+++ b/headless-services/boot-java-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>boot-java-language-server</artifactId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/empty-boot-15-web-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/no-actuator-boot-15-web-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-autowired/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-beans/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotation-indexing-parent/test-annotation-indexing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>test-annotation-indexing</artifactId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-annotations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-conditionals-live-hover/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-live-hover/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework</groupId>

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/mvnw
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/mvnw.cmd
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/pom.xml
+++ b/headless-services/boot-java-language-server/src/test/resources/test-projects/test-request-mapping-symbols/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/pom.xml
+++ b/headless-services/boot-properties-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>boot-properties-language-server</artifactId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.0-properties-live-metadta/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>
@@ -21,7 +21,7 @@
 	<repositories>
 	  <repository>
 	    <id>libs-snapshot</id>
-	    <url>http://repo.spring.io/libs-snapshot</url>
+	    <url>https://repo.spring.io/libs-snapshot</url>
 	    <snapshots>
 	      <enabled>true</enabled>
 	    </snapshots>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.2.1-app-properties-list-of-pojo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.0-app-sts-4231/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-app-with-resource-prop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/boot-1.3.3-sts-4335/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/custom-properties-boot-project/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/empty-boot-1.3.0-with-mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/enums-boot-1.3.2-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw.cmd
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/pom.xml
+++ b/headless-services/boot-properties-language-server/src/test/resources/test-projects/tricky-getters-boot-1.3.1-app/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.test</groupId>

--- a/headless-services/bosh-language-server/pom.xml
+++ b/headless-services/bosh-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>bosh-language-server</artifactId>

--- a/headless-services/commons/commons-boot-app-cli/pom.xml
+++ b/headless-services/commons/commons-boot-app-cli/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-boot-app-cli</artifactId>
 	<name>commons-boot-app-cli</name>

--- a/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/mvnw
+++ b/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/mvnw.cmd
+++ b/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/pom.xml
+++ b/headless-services/commons/commons-boot-app-cli/src/test/resources/boot-apps/source-projects/actuator-client-20-test-subject/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/commons/commons-cf/pom.xml
+++ b/headless-services/commons/commons-cf/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-cf</artifactId>
 	<name>commons-cf</name>

--- a/headless-services/commons/commons-gradle/pom.xml
+++ b/headless-services/commons/commons-gradle/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	
 	<artifactId>commons-gradle</artifactId>

--- a/headless-services/commons/commons-java/pom.xml
+++ b/headless-services/commons/commons-java/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-java</artifactId>
 	<name>commons-java</name>

--- a/headless-services/commons/commons-language-server/pom.xml
+++ b/headless-services/commons/commons-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-language-server</artifactId>
 	<name>commons-language-server</name>

--- a/headless-services/commons/commons-maven/pom.xml
+++ b/headless-services/commons/commons-maven/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>commons-maven</artifactId>

--- a/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw
+++ b/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw.cmd
+++ b/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/pom.xml
+++ b/headless-services/commons/commons-maven/src/test/resources/empty-boot-project-with-classpath-file/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw
+++ b/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw.cmd
+++ b/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/pom.xml
+++ b/headless-services/commons/commons-maven/src/test/resources/gs-rest-service-cors-boot-1.4.1-with-classpath-file/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework</groupId>

--- a/headless-services/commons/commons-util/pom.xml
+++ b/headless-services/commons/commons-util/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-util</artifactId>
 	<name>commons-util</name>

--- a/headless-services/commons/commons-yaml/pom.xml
+++ b/headless-services/commons/commons-yaml/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>commons-yaml</artifactId>
 	<name>commons-yaml</name>

--- a/headless-services/commons/java-properties/pom.xml
+++ b/headless-services/commons/java-properties/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>java-properties</artifactId>
 	<description>Java Properties parser, AST and utilities</description>

--- a/headless-services/commons/language-server-test-harness/pom.xml
+++ b/headless-services/commons/language-server-test-harness/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>language-server-test-harness</artifactId>
 	<name>language-server-test-harness</name>

--- a/headless-services/commons/pom.xml
+++ b/headless-services/commons/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ide.vscode</groupId>
@@ -39,7 +39,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -47,7 +47,7 @@
 		<repository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -55,7 +55,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/headless-services/concourse-language-server/pom.xml
+++ b/headless-services/concourse-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>concourse-language-server</artifactId>

--- a/headless-services/manifest-yaml-language-server/pom.xml
+++ b/headless-services/manifest-yaml-language-server/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>manifest-yaml-language-server</artifactId>

--- a/headless-services/mvnw
+++ b/headless-services/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/headless-services/mvnw.cmd
+++ b/headless-services/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/headless-services/pom.xml
+++ b/headless-services/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             http://maven.apache.org/maven-v4_0_0.xsd">
+                             https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.ide.vscode</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/ (200) with 2 occurrences could not be migrated:  
   ([https](https://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/) result SSLHandshakeException).
* http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastSuccessfulBuild/artifact/build/p2-repository/ (200) with 1 occurrences could not be migrated:  
   ([https](https://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastSuccessfulBuild/artifact/build/p2-repository/) result SSLHandshakeException).
* http://sha256timestamp.ws.symantec.com/sha256/timestamp (400) with 2 occurrences could not be migrated:  
   ([https](https://sha256timestamp.ws.symantec.com/sha256/timestamp) result ConnectTimeoutException).
* http://s3-test.spring.io/sts4/vscode-extensions/ (403) with 7 occurrences could not be migrated:  
   ([https](https://s3-test.spring.io/sts4/vscode-extensions/) result SSLHandshakeException).
* http://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/maven-repository/ (404) with 1 occurrences could not be migrated:  
   ([https](https://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/maven-repository/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://proxy.eng.vmware.com:3128 (UnknownHostException) with 4 occurrences migrated to:  
  https://proxy.eng.vmware.com:3128 ([https](https://proxy.eng.vmware.com:3128) result UnknownHostException).
* http://dist.springsource.com/ (403) with 1 occurrences migrated to:  
  https://dist.springsource.com/ ([https](https://dist.springsource.com/) result 403).
* http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly (403) with 1 occurrences migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly ([https](https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly) result 403).
* http://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/ (403) with 2 occurrences migrated to:  
  https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/ ([https](https://download.springsource.com/release/TOOLS/third-party/m2e-sts310-signed/) result 403).
* http://dist.springframework.org/snapshot/IDE/nightly (404) with 3 occurrences migrated to:  
  https://dist.springframework.org/snapshot/IDE/nightly ([https](https://dist.springframework.org/snapshot/IDE/nightly) result 404).
* http://download.eclipse.org/eclipse/updates/4.7-M-builds (404) with 1 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.7-M-builds ([https](https://download.eclipse.org/eclipse/updates/4.7-M-builds) result 404).
* http://download.eclipse.org/eclipse/updates/4.8-I-builds/ (404) with 2 occurrences migrated to:  
  https://download.eclipse.org/eclipse/updates/4.8-I-builds/ ([https](https://download.eclipse.org/eclipse/updates/4.8-I-builds/) result 404).
* http://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/ (404) with 2 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/S20171130170529/repository/) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 2 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dist.springsource.com/release/TOOLS/mavendevtools/ with 2 occurrences migrated to:  
  https://dist.springsource.com/release/TOOLS/mavendevtools/ ([https](https://dist.springsource.com/release/TOOLS/mavendevtools/) result 200).
* http://download.eclipse.org/lsp4e/0.5.0milestone/ with 2 occurrences migrated to:  
  https://download.eclipse.org/lsp4e/0.5.0milestone/ ([https](https://download.eclipse.org/lsp4e/0.5.0milestone/) result 200).
* http://download.eclipse.org/lsp4e/snapshots/ with 4 occurrences migrated to:  
  https://download.eclipse.org/lsp4e/snapshots/ ([https](https://download.eclipse.org/lsp4e/snapshots/) result 200).
* http://download.eclipse.org/modeling/tmf/xtext/updates/milestones/ with 2 occurrences migrated to:  
  https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/ ([https](https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/) result 200).
* http://download.eclipse.org/releases/oxygen/ with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/oxygen/ ([https](https://download.eclipse.org/releases/oxygen/) result 200).
* http://download.eclipse.org/releases/photon/ with 2 occurrences migrated to:  
  https://download.eclipse.org/releases/photon/ ([https](https://download.eclipse.org/releases/photon/) result 200).
* http://download.eclipse.org/staging/oxygen/ with 2 occurrences migrated to:  
  https://download.eclipse.org/staging/oxygen/ ([https](https://download.eclipse.org/staging/oxygen/) result 200).
* http://download.eclipse.org/staging/photon/ with 2 occurrences migrated to:  
  https://download.eclipse.org/staging/photon/ ([https](https://download.eclipse.org/staging/photon/) result 200).
* http://download.eclipse.org/technology/m2e/milestones/1.8/ with 2 occurrences migrated to:  
  https://download.eclipse.org/technology/m2e/milestones/1.8/ ([https](https://download.eclipse.org/technology/m2e/milestones/1.8/) result 200).
* http://download.eclipse.org/tm4e/snapshots/ with 2 occurrences migrated to:  
  https://download.eclipse.org/tm4e/snapshots/ ([https](https://download.eclipse.org/tm4e/snapshots/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/ with 2 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20170919201930/repository/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/latest-I/ with 2 occurrences migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/latest-I/ ([https](https://download.eclipse.org/tools/orbit/downloads/latest-I/) result 200).
* http://download.jboss.org/jbosstools/updates/m2e-wro4j/ with 2 occurrences migrated to:  
  https://download.jboss.org/jbosstools/updates/m2e-wro4j/ ([https](https://download.jboss.org/jbosstools/updates/m2e-wro4j/) result 200).
* http://ianbrandt.github.io/m2e-maven-dependency-plugin/ with 2 occurrences migrated to:  
  https://ianbrandt.github.io/m2e-maven-dependency-plugin/ ([https](https://ianbrandt.github.io/m2e-maven-dependency-plugin/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 35 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/ with 2 occurrences migrated to:  
  https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/ ([https](https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-egit/0.14.0/N/0.14.0.201504071521/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 46 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.eclipse.org/legal/epl-v10.html with 2 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://download.eclipse.org/buildship/updates/e47/releases/2.x with 2 occurrences migrated to:  
  https://download.eclipse.org/buildship/updates/e47/releases/2.x ([https](https://download.eclipse.org/buildship/updates/e47/releases/2.x) result 301).
* http://download.eclipse.org/egit/github/updates with 1 occurrences migrated to:  
  https://download.eclipse.org/egit/github/updates ([https](https://download.eclipse.org/egit/github/updates) result 301).
* http://download.eclipse.org/technology/m2e/releases with 2 occurrences migrated to:  
  https://download.eclipse.org/technology/m2e/releases ([https](https://download.eclipse.org/technology/m2e/releases) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 30 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.mihai-nita.net/eclipse with 2 occurrences migrated to:  
  https://www.mihai-nita.net/eclipse ([https](https://www.mihai-nita.net/eclipse) result 301).
* http://maven.springframework.org/release with 2 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/milestone with 1 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 130 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 65 occurrences