### PR TITLE
URL Cleanup

### DIFF
--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataGroup.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataHint.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataHint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataItem.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataProperty.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepository.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataRepositoryJsonBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataSource.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ConfigurationMetadataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/Deprecation.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/Deprecation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/DescriptionExtractor.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/DescriptionExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/Hints.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/Hints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/JsonReader.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/JsonReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/RawConfigurationMetadata.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/RawConfigurationMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/SimpleConfigurationMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ValueHint.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ValueHint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ValueProvider.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/ValueProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/package-info.java
+++ b/vscode-extensions/commons/application-properties-metadata/src/main/java/org/springframework/boot/configurationmetadata/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 16 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).