### PR TITLE
gradlize and add support for better language server loading

### DIFF
--- a/idea-extensions/idea-boot-java/.gitignore
+++ b/idea-extensions/idea-boot-java/.gitignore
@@ -1,3 +1,5 @@
-/resources/server/language-server.jar
+/server/language-server.jar
 /.idea
 *.iml
+*.zip
+/gradle/

--- a/idea-extensions/idea-boot-java/build.gradle
+++ b/idea-extensions/idea-boot-java/build.gradle
@@ -1,0 +1,49 @@
+plugins {
+    id "org.jetbrains.intellij" version "0.4.5"
+}
+
+repositories {
+    mavenCentral()
+}
+
+intellij {
+    version '2017.3'
+    plugins = ['IntelliLang', 'com.github.gtache.lsp:1.5.4']
+    pluginName 'idea-boot-java'
+    downloadSources = false
+}
+
+patchPluginXml {
+    untilBuild '2019.3'
+}
+
+dependencies {
+    compile 'org.scala-lang:scala-compiler:2.12.7'
+    compile 'org.scala-lang:scala-library:2.12.7'
+}
+
+apply plugin: 'scala'
+sourceSets {
+    main {
+        scala {
+            srcDirs = ['src']
+        }
+        java {
+            srcDirs = []
+        }
+        resources {
+            srcDirs = ['resources']
+        }
+    }
+}
+
+prepareSandbox.doLast {
+    def pluginServerDir = "${intellij.sandboxDirectory}/plugins/idea-boot-java/lib/server"
+
+    mkdir(pluginServerDir)
+    copy {
+        from("$project.projectDir/server/language-server.jar")
+        into(pluginServerDir)
+    }
+}
+

--- a/idea-extensions/idea-boot-java/gradlew
+++ b/idea-extensions/idea-boot-java/gradlew
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
+function splitJvmOpts() {
+    JVM_OPTS=("$@")
+}
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/idea-extensions/idea-boot-java/gradlew.bat
+++ b/idea-extensions/idea-boot-java/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/idea-extensions/idea-boot-java/settings.gradle
+++ b/idea-extensions/idea-boot-java/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'idea-boot-java'

--- a/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
+++ b/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
@@ -24,7 +24,7 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
 
     val javaPath = Paths.get(javaHome)
 
-    val javaExec = javaPath.resolve(Paths.get("bin", if(isWindows()) "java.exe" else "java"))
+    val javaExec = javaPath.resolve(Paths.get("bin", if (isWindows()) "java.exe" else "java"))
 
     if (!Files.exists(javaExec)) {
       // TODO throw error?
@@ -38,11 +38,11 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
     if (javaVersion.startsWith("1.8")) {
         var toolsJar = javaPath.resolve(Paths.get("lib", "tools.jar"))
         if (Files.exists(toolsJar)) {
-          classpath += ":" + toolsJar
+          classpath += File.pathSeparator + toolsJar
         } else {
           toolsJar = javaPath.resolve(Paths.get("..", "lib", "tools.jar"))
           if (Files.exists(toolsJar)) {
-            classpath += ":" + toolsJar
+            classpath += File.pathSeparator + toolsJar
           } else {
             // TODO: tools.jar doesn't exist
           }
@@ -52,6 +52,9 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
     } else {
       // Error - not Java 8 or 9
     }
+
+    // wrap class path for spaces in path
+    classpath = "\'" + classpath + "\'"
 
     LanguageServerDefinition.register(
       new StsServerDefinition("java", Array(

--- a/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
+++ b/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
@@ -24,7 +24,7 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
 
     val javaPath = Paths.get(javaHome)
 
-    val javaExec = javaPath.resolve(Paths.get("bin", "java"))
+    val javaExec = javaPath.resolve(Paths.get("bin", if(isWindows()) "java.exe" else "java"))
 
     if (!Files.exists(javaExec)) {
       // TODO throw error?
@@ -62,4 +62,7 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
       )))
   }
 
+  def isWindows(): Boolean = {
+    return System.getProperty("os.name").toLowerCase().startsWith("win")
+  }
 }

--- a/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
+++ b/idea-extensions/idea-boot-java/src/org/spring/tools/boot/java/ls/BootJavaPreloadingActivity.scala
@@ -31,8 +31,9 @@ class BootJavaPreloadingActivity extends PreloadingActivity {
       return
     }
 
-    var classpath = getClass().getResource("/server/language-server.jar").getPath()
-
+    // search for the server jar near to jar file or class folder
+    val root = new File(getClass().getResource("/").toURI.getPath)
+    var classpath = new File(root.getParent, "/server/language-server.jar").getPath()
 
     if (javaVersion.startsWith("1.8")) {
         var toolsJar = javaPath.resolve(Paths.get("lib", "tools.jar"))


### PR DESCRIPTION
When the server jar is inside classpath the final packaged plugin cause
the server jar to be packaged inside the plugin jar which cause it to
fail. Now the server jar is packed outside with the support of gradle.

Signed-off-by: gayanper <gayanper@gmail.com>