### PR TITLE
Track symbol dependencies ...

### DIFF
--- a/headless-services/commons/commons-util/src/main/java/org/springframework/ide/vscode/commons/util/UriUtil.java
+++ b/headless-services/commons/commons-util/src/main/java/org/springframework/ide/vscode/commons/util/UriUtil.java
@@ -65,4 +65,20 @@ public class UriUtil {
 		}
 	}
 
+	public static File toFile(String docURI) {
+		try {
+			return new File(new URI(docURI));
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	public static String toFileString(String docURI) {
+		try {
+			return new File(new URI(docURI)).getAbsolutePath();
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/app/SpringSymbolIndex.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/app/SpringSymbolIndex.java
@@ -284,6 +284,10 @@ public class SpringSymbolIndex implements InitializingBean {
 		}
 	}
 
+	public SpringIndexerJava getJavaIndexer() {
+		return springIndexerJava;
+	}
+	
 	public CompletableFuture<Void> deleteProject(IJavaProject project) {
 		try {
 			if (project.getElementName() == null) {

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/FileScanListener.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/FileScanListener.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.vscode.boot.java.utils;
+
+public interface FileScanListener {
+	void fileScanned(String path);
+}

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerJava.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerJava.java
@@ -18,14 +18,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
@@ -54,12 +57,14 @@ import org.springframework.ide.vscode.commons.util.UriUtil;
 import org.springframework.ide.vscode.commons.util.text.TextDocument;
 
 import com.google.common.base.Supplier;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 
 /**
  * @author Martin Lippert
  */
 public class SpringIndexerJava implements SpringIndexer {
-
+	
 	public static enum SCAN_PASS {
 		ONE, TWO
 	}
@@ -72,6 +77,42 @@ public class SpringIndexerJava implements SpringIndexer {
 	private final JavaProjectFinder projectFinder;
 	private boolean scanTestJavaSources = false;
 
+	private final DependencyTracker dependencyTracker = new DependencyTracker();
+
+	static class DependencyTracker {
+		
+		private Multimap<String, String> dependencies = MultimapBuilder.hashKeys().hashSetValues().build();
+		
+		public void addDependency(String sourceFile, ITypeBinding dependsOn) {
+			dependencies.put(sourceFile, dependsOn.getKey());
+		}
+		
+		public void dump() {
+			log.info("=== Dependencies ===");
+			for (String sourceFile : dependencies.keySet()) {
+				Collection<String> values = dependencies.get(sourceFile);
+				if (!values.isEmpty())
+				log.info(sourceFile + "=> ");
+				for (String v : values) {
+					log.info("   "+v);
+				}
+			}
+			log.info("======================");
+		}
+
+		public Multimap<String, String> getAllDependencies() {
+			return dependencies;
+		}
+
+		public void update(String file, Set<String> dependenciesForFile) {
+			dependencies.replaceValues(file, dependenciesForFile);
+		}
+
+		public void restore(Multimap<String, String> deps) {
+			this.dependencies = deps;
+		}
+	}
+	
 	public SpringIndexerJava(SymbolHandler symbolHandler, AnnotationHierarchyAwareLookup<SymbolProvider> symbolProviders, SymbolCache cache,
 			JavaProjectFinder projectFimder) {
 		this.symbolHandler = symbolHandler;
@@ -132,8 +173,80 @@ public class SpringIndexerJava implements SpringIndexer {
 	}
 
 	private void scanFile(IJavaProject project, String docURI, long lastModified, String content) throws Exception {
+		//TODO: optimise? Check last modified to avoid redundant scan. Reason:
+		//  on saving a file, this may be triggered twice. Once when file is saved and once more because of a 'file changed'
+		//  on file system. Looking at the timestamp in the cache we should be able to avoid a second scan of the exact same
+		//  content.
 		ASTParser parser = createParser(project, false);
 
+		String unitName = docURI.substring(docURI.lastIndexOf("/"));
+		parser.setUnitName(unitName);
+		log.debug("Scan file: {}", unitName);
+		parser.setSource(content.toCharArray());
+
+		CompilationUnit cu = (CompilationUnit) parser.createAST(null);
+
+		if (cu != null) {
+			List<CachedSymbol> generatedSymbols = new ArrayList<CachedSymbol>();
+			AtomicReference<TextDocument> docRef = new AtomicReference<>();
+			String file = UriUtil.toFileString(docURI);
+
+			Set<String> changedTypes = new HashSet<>();
+			SpringIndexerJavaContext context = new SpringIndexerJavaContext(project, cu, docURI, file,
+					lastModified, docRef, content, generatedSymbols, SCAN_PASS.ONE, new ArrayList<>(), changedTypes);
+
+			scanAST(context);
+
+			SymbolCacheKey cacheKey = getCacheKey(project);
+			this.cache.update(cacheKey, file, lastModified, generatedSymbols, context.getDependencies());
+//			dependencyTracker.dump();
+
+			for (CachedSymbol symbol : generatedSymbols) {
+				symbolHandler.addSymbol(project, symbol.getDocURI(), symbol.getEnhancedSymbol());
+			}
+			Set<String> scannedFiles = new HashSet<>();
+			scannedFiles.add(file);
+			scanAffectedFiles(project, changedTypes, scannedFiles);
+		}
+	}
+
+	private void scanAffectedFiles(IJavaProject project, Set<String> changedTypes, Set<String> scannedFiles) {
+		log.info("Start scanning affected files for types {}", changedTypes);
+		//TODO: optimise? When multiple files are 'affected', we could try to parse and scan them in batch. 
+		// I.e. something similar to the 'scanFiles' method.
+		// That is probably more efficient than one by one.
+		
+		Multimap<String, String> dependencies = dependencyTracker.getAllDependencies();
+//		Collection<String> filesToScan = new HashSet<>();
+		boolean scannedAnyFiles;
+		do {
+			scannedAnyFiles = false;
+			for (String file : dependencies.keys()) {
+				try {
+					if (!scannedFiles.contains(file)) {
+						Collection<String> dependsOn = dependencies.get(file);
+						if (dependsOn.stream().anyMatch(changedTypes::contains)) {
+							scannedFiles.add(file);
+							scannedAnyFiles = true;
+							log.debug("Should also scan affected file: {}", file);
+							File f = new File(file);
+							scanAffectedFile(project, UriUtil.toUri(f).toString(), f.lastModified(), FileUtils.readFileToString(f), changedTypes);
+						}
+					}
+				} catch (Exception e) {
+					log.debug("Problems scanning file {}", file, e);
+				}
+			}
+			if (scannedAnyFiles) {
+				log.debug("Some affected files where scanned, make another pass");
+			}
+		} while (scannedAnyFiles);
+		log.info("Finished scanning affected files {}", scannedFiles);
+	}
+
+	private void scanAffectedFile(IJavaProject project, String docURI, long lastModified, String content, Set<String> changedTypes) throws Exception {
+		symbolHandler.removeSymbols(project, docURI);
+		ASTParser parser = createParser(project, false);
 		String unitName = docURI.substring(docURI.lastIndexOf("/"));
 		parser.setUnitName(unitName);
 		parser.setSource(content.toCharArray());
@@ -143,27 +256,32 @@ public class SpringIndexerJava implements SpringIndexer {
 		if (cu != null) {
 			List<CachedSymbol> generatedSymbols = new ArrayList<CachedSymbol>();
 			AtomicReference<TextDocument> docRef = new AtomicReference<>();
-			String file = new File(new URI(docURI)).getAbsolutePath();
+			File file = UriUtil.toFile(docURI);
+			if (file!=null) {
+				SpringIndexerJavaContext context = new SpringIndexerJavaContext(
+						project, cu, 
+						docURI, file.toString(), lastModified, docRef, 
+						content, generatedSymbols, 
+						SCAN_PASS.ONE, new ArrayList<>(), changedTypes);
+				scanAST(context);
 
-			SpringIndexerJavaContext context = new SpringIndexerJavaContext(project, cu, docURI, file,
-					lastModified, docRef, content, generatedSymbols, SCAN_PASS.ONE, new ArrayList<>());
+				SymbolCacheKey cacheKey = getCacheKey(project);
+				this.cache.update(cacheKey, file.getAbsolutePath(), lastModified, generatedSymbols, context.getDependencies());
+//				dependencyTracker.dump();
 
-			scanAST(context);
-
-			SymbolCacheKey cacheKey = getCacheKey(project);
-			this.cache.update(cacheKey, file, lastModified, generatedSymbols);
-
-			for (CachedSymbol symbol : generatedSymbols) {
-				symbolHandler.addSymbol(project, symbol.getDocURI(), symbol.getEnhancedSymbol());
+				for (CachedSymbol symbol : generatedSymbols) {
+					symbolHandler.addSymbol(project, symbol.getDocURI(), symbol.getEnhancedSymbol());
+				}
 			}
 		}
 	}
 
 	private void scanFiles(IJavaProject project, String[] javaFiles) throws Exception {
 		SymbolCacheKey cacheKey = getCacheKey(project);
-		CachedSymbol[] symbols = this.cache.retrieve(cacheKey, javaFiles);
+		Pair<CachedSymbol[], Multimap<String, String>> cached = this.cache.retrieve(cacheKey, javaFiles);
 
-		if (symbols == null) {
+		CachedSymbol[] symbols;
+		if (cached == null) {
 			List<CachedSymbol> generatedSymbols = new ArrayList<CachedSymbol>();
 
 			log.info("scan java files, AST parse, pass 1 for files: {}", javaFiles.length);
@@ -176,12 +294,16 @@ public class SpringIndexerJava implements SpringIndexer {
 				scanFiles(project, pass2Files, generatedSymbols, SCAN_PASS.TWO);
 			}
 
-			this.cache.store(cacheKey, javaFiles, generatedSymbols);
+			this.cache.store(cacheKey, javaFiles, generatedSymbols, dependencyTracker.getAllDependencies());
+//			dependencyTracker.dump();
 
 			symbols = (CachedSymbol[]) generatedSymbols.toArray(new CachedSymbol[generatedSymbols.size()]);
 		}
 		else {
+			symbols = cached.getLeft();
 			log.info("scan java files used cached data: {} - no. of cached symbols retrieved: {}", project.getElementName(), symbols.length);
+			this.dependencyTracker.restore(cached.getRight());
+			log.info("scan java files restored cached dependency data: {} - no. of cached dependencies: {}", cached.getRight().size());
 		}
 
 		if (symbols != null) {
@@ -206,7 +328,7 @@ public class SpringIndexerJava implements SpringIndexer {
 				AtomicReference<TextDocument> docRef = new AtomicReference<>();
 
 				SpringIndexerJavaContext context = new SpringIndexerJavaContext(project, cu, docURI, sourceFilePath,
-						lastModified, docRef, null, generatedSymbols, pass, nextPassFiles);
+						lastModified, docRef, null, generatedSymbols, pass, nextPassFiles, null);
 
 				scanAST(context);
 			}
@@ -218,12 +340,18 @@ public class SpringIndexerJava implements SpringIndexer {
 	}
 
 	private void scanAST(final SpringIndexerJavaContext context) {
-
 		context.getCu().accept(new ASTVisitor() {
 
 			@Override
 			public boolean visit(TypeDeclaration node) {
 				try {
+					Set<String> changedTypes = context.getChangedTypes();
+					if (changedTypes!=null) {
+						ITypeBinding changedType = node.resolveBinding();
+						if (changedType!=null) {
+							changedTypes.add(changedType.getKey());
+						}
+					}
 					extractSymbolInformation(node, context);
 				}
 				catch (Exception e) {
@@ -279,6 +407,7 @@ public class SpringIndexerJava implements SpringIndexer {
 				return super.visit(node);
 			}
 		});
+		dependencyTracker.update(context.getFile(), context.getDependencies());;
 	}
 
 	private void extractSymbolInformation(TypeDeclaration typeDeclaration, final SpringIndexerJavaContext context) throws Exception {

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerJavaContext.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerJavaContext.java
@@ -10,10 +10,13 @@
  *******************************************************************************/
 package org.springframework.ide.vscode.boot.java.utils;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.springframework.ide.vscode.boot.java.utils.SpringIndexerJava.SCAN_PASS;
 import org.springframework.ide.vscode.commons.java.IJavaProject;
 import org.springframework.ide.vscode.commons.util.text.TextDocument;
@@ -33,10 +36,22 @@ public class SpringIndexerJavaContext {
 	private final List<CachedSymbol> generatedSymbols;
 	private final SCAN_PASS pass;
 	private final List<String> nextPassFiles;
+	private final Set<String> dependencies = new HashSet<>();
+	private final Set<String> dependentTypes;
 
-	public SpringIndexerJavaContext(IJavaProject project, CompilationUnit cu, String docURI, String file, long lastModified,
-			AtomicReference<TextDocument> docRef, String content, List<CachedSymbol> generatedSymbols, SCAN_PASS pass,
-			List<String> nextPassFiles) {
+	public SpringIndexerJavaContext(
+			IJavaProject project, 
+			CompilationUnit cu, 
+			String docURI, 
+			String file, 
+			long lastModified,
+			AtomicReference<TextDocument> docRef, 
+			String content, 
+			List<CachedSymbol> generatedSymbols, 
+			SCAN_PASS pass,
+			List<String> nextPassFiles, 
+			Set<String> dependentTypes
+	) {
 		super();
 		this.project = project;
 		this.cu = cu;
@@ -48,6 +63,7 @@ public class SpringIndexerJavaContext {
 		this.generatedSymbols = generatedSymbols;
 		this.pass = pass;
 		this.nextPassFiles = nextPassFiles;
+		this.dependentTypes = dependentTypes;
 	}
 
 	public IJavaProject getProject() {
@@ -88,6 +104,18 @@ public class SpringIndexerJavaContext {
 
 	public List<String> getNextPassFiles() {
 		return nextPassFiles;
+	}
+
+	public Set<String> getDependencies() {
+		return dependencies;
+	}
+	
+	public void addDependency(ITypeBinding dependsOn) {
+		dependencies.add(dependsOn.getKey());
+	}
+
+	public Set<String> getChangedTypes() {
+		return dependentTypes;
 	}
 
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerXML.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SpringIndexerXML.java
@@ -105,7 +105,7 @@ public class SpringIndexerXML implements SpringIndexer {
 		long startTime = System.currentTimeMillis();
 		SymbolCacheKey cacheKey = getCacheKey(project);
 
-		CachedSymbol[] symbols = this.cache.retrieve(cacheKey, files);
+		CachedSymbol[] symbols = this.cache.retrieveSymbols(cacheKey, files);
 		if (symbols == null) {
 			List<CachedSymbol> generatedSymbols = new ArrayList<CachedSymbol>();
 
@@ -113,7 +113,7 @@ public class SpringIndexerXML implements SpringIndexer {
 				scanFile(project, file, generatedSymbols);
 			}
 
-			this.cache.store(cacheKey, files, generatedSymbols);
+			this.cache.store(cacheKey, files, generatedSymbols, null);
 
 			symbols = (CachedSymbol[]) generatedSymbols.toArray(new CachedSymbol[generatedSymbols.size()]);
 		}
@@ -148,7 +148,7 @@ public class SpringIndexerXML implements SpringIndexer {
 
 		SymbolCacheKey cacheKey = getCacheKey(project);
 		String file = new File(new URI(docURI)).getAbsolutePath();
-		this.cache.update(cacheKey, file, lastModified, generatedSymbols);
+		this.cache.update(cacheKey, file, lastModified, generatedSymbols, null);
 
 		for (CachedSymbol symbol : generatedSymbols) {
 			symbolHandler.addSymbol(project, symbol.getDocURI(), symbol.getEnhancedSymbol());

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SymbolCache.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SymbolCache.java
@@ -11,18 +11,27 @@
 package org.springframework.ide.vscode.boot.java.utils;
 
 import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.Multimap;
 
 /**
  * @author Martin Lippert
  */
 public interface SymbolCache {
 
-	void store(SymbolCacheKey cacheKey, String[] files, List<CachedSymbol> generatedSymbols);
-	CachedSymbol[] retrieve(SymbolCacheKey cacheKey, String[] files);
+	void store(SymbolCacheKey cacheKey, String[] files, List<CachedSymbol> generatedSymbols, Multimap<String, String> dependencies);
+	Pair<CachedSymbol[], Multimap<String, String>> retrieve(SymbolCacheKey cacheKey, String[] files);
 
-	void update(SymbolCacheKey cacheKey, String file, long lastModified, List<CachedSymbol> generatedSymbols);
+	void update(SymbolCacheKey cacheKey, String file, long lastModified, List<CachedSymbol> generatedSymbols, Set<String> dependencies);
 
 	void remove(SymbolCacheKey cacheKey);
 	void removeFile(SymbolCacheKey symbolCacheKey, String file);
+	default CachedSymbol[] retrieveSymbols(SymbolCacheKey cacheKey, String[] files) {
+		Pair<CachedSymbol[], Multimap<String, String>> r = retrieve(cacheKey, files);
+		return r!=null ? r.getLeft() : null;
+	}
 
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SymbolCacheVoid.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/SymbolCacheVoid.java
@@ -11,6 +11,11 @@
 package org.springframework.ide.vscode.boot.java.utils;
 
 import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.Multimap;
 
 /**
  * @author Martin Lippert
@@ -18,16 +23,16 @@ import java.util.List;
 public class SymbolCacheVoid implements SymbolCache {
 
 	@Override
-	public void store(SymbolCacheKey cacheKey, String[] files, List<CachedSymbol> generatedSymbols) {
+	public void store(SymbolCacheKey cacheKey, String[] files, List<CachedSymbol> generatedSymbols, Multimap<String,String> dependencies) {
 	}
 
 	@Override
-	public CachedSymbol[] retrieve(SymbolCacheKey cacheKey, String[] files) {
+	public Pair<CachedSymbol[], Multimap<String, String>> retrieve(SymbolCacheKey cacheKey, String[] files) {
 		return null;
 	}
 
 	@Override
-	public void update(SymbolCacheKey cacheKey, String file, long lastModified, List<CachedSymbol> generatedSymbols) {
+	public void update(SymbolCacheKey cacheKey, String file, long lastModified, List<CachedSymbol> generatedSymbols, Set<String> dependencies) {
 	}
 
 	@Override
@@ -37,5 +42,6 @@ public class SymbolCacheVoid implements SymbolCache {
 	@Override
 	public void removeFile(SymbolCacheKey symbolCacheKey, String file) {
 	}
+
 
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/metadata/AdHocSpringPropertyIndexProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/metadata/AdHocSpringPropertyIndexProvider.java
@@ -63,9 +63,9 @@ public class AdHocSpringPropertyIndexProvider implements ProjectBasedPropertyInd
 					"**/application.properties",
 					"**/application.yml"
 			), changed -> {
-				log.info("File changed: "+changed);
+				log.debug("File changed: {}", changed);
 				projectFinder.find(new TextDocumentIdentifier(changed)).ifPresent(project -> {
-					log.info("=> Project changed: "+project.getElementName());
+					log.debug("=> Project changed: {}", project.getElementName());
 					indexes.invalidate(project);
 				});
 			});

--- a/headless-services/spring-boot-language-server/src/main/resources/application.properties
+++ b/headless-services/spring-boot-language-server/src/main/resources/application.properties
@@ -4,3 +4,7 @@ languageserver.completion-trigger-characters.xml:
 languageserver.completion-trigger-characters.spring-boot-properties-yaml: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.
 languageserver.completion-trigger-characters.spring-boot-properties: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.
 spring.main.banner-mode: off
+
+#logging.level.org.springframework.ide.vscode.boot.java.utils.SpringIndexerJava=debug
+#logging.level.org.springframework.ide.vscode.boot.app.SpringSymbolIndex=debug
+#logging.level.org.springframework.ide.vscode.commons.boot.app.cli.SpringBootApp=off

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/requestmapping/test/RequestMappingDependentConstantChangedTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/requestmapping/test/RequestMappingDependentConstantChangedTest.java
@@ -1,0 +1,165 @@
+package org.springframework.ide.vscode.boot.java.requestmapping.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.ide.vscode.boot.app.SpringSymbolIndex;
+import org.springframework.ide.vscode.boot.bootiful.BootLanguageServerTest;
+import org.springframework.ide.vscode.boot.bootiful.SymbolProviderTestConf;
+import org.springframework.ide.vscode.commons.languageserver.java.JavaProjectFinder;
+import org.springframework.ide.vscode.commons.maven.java.MavenJavaProject;
+import org.springframework.ide.vscode.commons.util.UriUtil;
+import org.springframework.ide.vscode.commons.util.text.LanguageId;
+import org.springframework.ide.vscode.commons.util.text.TextDocument;
+import org.springframework.ide.vscode.project.harness.BootLanguageServerHarness;
+import org.springframework.ide.vscode.project.harness.ProjectsHarness;
+import org.springframework.ide.vscode.project.harness.ProjectsHarness.CustomizableProjectContent;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@BootLanguageServerTest
+@Import(SymbolProviderTestConf.class)
+public class RequestMappingDependentConstantChangedTest {
+
+	@Autowired private BootLanguageServerHarness harness;
+	@Autowired private JavaProjectFinder projectFinder;
+	@Autowired private SpringSymbolIndex indexer;
+
+	ProjectsHarness projects = ProjectsHarness.INSTANCE;
+	private MavenJavaProject project;
+	private Path directory;
+	
+	@Before
+	public void setup() throws Exception {
+		harness.intialize(null);
+
+		project = (MavenJavaProject) projects.mavenProject("test-request-mapping-symbols", false, new ProjectsHarness.ProjectCustomizer() {
+			@Override
+			public void customize(CustomizableProjectContent projectContent) throws Exception {
+				//dummy (forces every test to use a new copy of the project, we do this because project
+				//files are being mutated!
+			}
+		});
+		directory = new File(project.getLocationUri()).toPath();
+
+		// trigger project creation
+		projectFinder.find(new TextDocumentIdentifier(project.getLocationUri().toString())).get();
+
+		CompletableFuture<Void> initProject = indexer.waitOperation();
+		initProject.get(5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	public void testSimpleRequestMappingSymbolFromConstantInDifferentClass() throws Exception {
+		String docUri = directory.resolve("src/main/java/org/test/SimpleMappingClassWithConstantInDifferentClass.java").toUri().toString();
+		String constantsUri = directory.resolve("src/main/java/org/test/Constants.java").toUri().toString();
+		List<? extends SymbolInformation> symbols = indexer.getSymbols(docUri);
+		assertEquals(1, symbols.size());
+		assertSymbol(docUri, "@/path/from/constant", "@RequestMapping(Constants.REQUEST_MAPPING_PATH)");
+
+		TestFileScanListener fileScanListener = new TestFileScanListener();
+		indexer.getJavaIndexer().setFileScanListener(fileScanListener);
+		
+		replaceInFile(constantsUri, "path/from/constant", "/changed-path");
+		fileScanListener.assertScannedUris(constantsUri, docUri);
+		fileScanListener.assertScannedUri(constantsUri, 1);
+		fileScanListener.assertScannedUri(docUri, 1);
+		
+		symbols = indexer.getSymbols(docUri);
+		assertSymbolCount(1, symbols);
+		assertSymbol(docUri, "@/changed-path", "@RequestMapping(Constants.REQUEST_MAPPING_PATH)");
+	}
+	
+	@Test public void testCyclicalDependency() throws Exception {
+		//cyclical dependency between two files (ping refers pong and vice versa)
+		
+		String pingUri = directory.resolve("src/main/java/org/test/PingConstantRequestMapping.java").toUri().toString();
+		String pongUri = directory.resolve("src/main/java/org/test/PongConstantRequestMapping.java").toUri().toString();
+
+		{
+			List<? extends SymbolInformation> symbols = indexer.getSymbols(pingUri);
+			for (SymbolInformation s : symbols) {
+				System.out.println(s.getName());
+			}
+			assertSymbolCount(1, symbols);
+			assertSymbol(pingUri, "@/pong -- GET", "@GetMapping(PongConstantRequestMapping.PONG)");
+		}
+		{
+			List<? extends SymbolInformation> symbols = indexer.getSymbols(pongUri);
+			assertSymbolCount(1, symbols);
+			assertSymbol(pongUri, "@/ping -- GET", "@GetMapping(PingConstantRequestMapping.PING)");
+		}
+
+		replaceInFile(pingUri, "/ping", "/changed");
+
+		{
+			List<? extends SymbolInformation> symbols = indexer.getSymbols(pingUri);
+			assertSymbolCount(1, symbols);
+			assertSymbol(pingUri, "@/pong -- GET", "@GetMapping(PongConstantRequestMapping.PONG)");
+		}
+		{
+			List<? extends SymbolInformation> symbols = indexer.getSymbols(pongUri);
+			assertSymbolCount(1, symbols);
+			assertSymbol(pongUri, "@/changed -- GET", "@GetMapping(PingConstantRequestMapping.PING)");
+		}
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////////
+	
+	private void assertSymbolCount(int expectedCount, List<? extends SymbolInformation> symbols) {
+		if (symbols.size()!=expectedCount) {
+			StringBuilder found = new StringBuilder();
+			for (SymbolInformation s : symbols) {
+				found.append(s.getName());
+				found.append("\n");
+			}
+			fail("Expected "+expectedCount+" symbols but found "+symbols.size()+":\n"+found);
+		}
+	}
+
+	private void assertSymbol(String docUri, String name, String coveredText) throws Exception {
+		List<? extends SymbolInformation> symbols = indexer.getSymbols(docUri);
+		Optional<? extends SymbolInformation> maybeSymbol = symbols.stream().filter(s -> name.equals(s.getName())).findFirst();
+		assertTrue(maybeSymbol.isPresent());
+		
+		TextDocument doc = new TextDocument(docUri, LanguageId.JAVA);
+		doc.setText(FileUtils.readFileToString(UriUtil.toFile(docUri)));
+		
+		SymbolInformation symbol = maybeSymbol.get();
+		Location loc = symbol.getLocation();
+		assertEquals(docUri, loc.getUri());
+		int start = doc.toOffset(loc.getRange().getStart());
+		int end = doc.toOffset(loc.getRange().getEnd());
+		String actualCoveredText = doc.textBetween(start, end);
+		assertEquals(coveredText, actualCoveredText);
+	}
+	
+	public void replaceInFile(String docUri, String find, String replace) throws Exception {
+		File target = UriUtil.toFile(docUri);
+		String oldContent = FileUtils.readFileToString(target, "UTF8");
+		assertTrue(oldContent.contains(find));
+		String newContent = oldContent.replace(find, replace);
+		FileUtils.write(target, newContent, "UTF8");
+		
+		indexer.updateDocument(docUri, null, "triggered by test code").get();
+	}
+}

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/requestmapping/test/TestFileScanListener.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/requestmapping/test/TestFileScanListener.java
@@ -1,0 +1,58 @@
+package org.springframework.ide.vscode.boot.java.requestmapping.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.springframework.ide.vscode.boot.java.utils.FileScanListener;
+import org.springframework.ide.vscode.commons.util.UriUtil;
+
+public class TestFileScanListener implements FileScanListener {
+	public final List<String> scannedFiles = new ArrayList<String>();
+
+	@Override
+	public void fileScanned(String path) {
+		scannedFiles.add(path);
+	}
+
+	public void assertScanned(String path) {
+		assertTrue(scannedFiles.contains(path));
+	}
+	
+	public void assertScanned(String path, int scanCount) {
+		assertEquals(scanCount, scannedFiles.stream().filter(e -> e.equals(path)).count());
+	}
+
+	public void assertScannedUris(String... docUris) {
+		List<String> docPaths = new ArrayList<>();
+		for (String docUri : docUris) {
+			docPaths.add(UriUtil.toFileString(docUri));
+		}
+		Collections.sort(docPaths);
+		StringBuilder expected = new StringBuilder();
+		for (String string : docPaths) {
+			expected.append(string+"\n");
+		}
+		TreeSet<String> actualPaths = new TreeSet<>();
+		for (String string : scannedFiles) {
+			actualPaths.add(string);
+		}
+		StringBuilder actual = new StringBuilder();
+		for (String string : actualPaths) {
+			actual.append(string+"\n");
+		}
+		assertEquals(expected.toString(), actual.toString());
+	}
+
+	public void assertScannedUri(String docUri, int scanCount) {
+		assertScanned(UriUtil.toFileString(docUri), scanCount);
+	}
+
+	public void reset() {
+		scannedFiles.clear();
+	}
+}

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/utils/test/SpringIndexerTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/utils/test/SpringIndexerTest.java
@@ -161,7 +161,7 @@ public class SpringIndexerTest {
 		assertTrue(containsSymbol(indexer.getSymbols(changedDocURI), "@/mapping1", changedDocURI));
 
 		String newContent = FileUtils.readFileToString(new File(new URI(changedDocURI))).replace("mapping1", "mapping1-CHANGED");
-		CompletableFuture<Void> updateFuture = indexer.updateDocument(changedDocURI, newContent);
+		CompletableFuture<Void> updateFuture = indexer.updateDocument(changedDocURI, newContent, "test triggered");
 		updateFuture.get(5, TimeUnit.SECONDS);
 
 		// check for updated index per document

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/project/harness/ProjectsHarness.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/project/harness/ProjectsHarness.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.springframework.ide.vscode.project.harness;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +75,7 @@ public class ProjectsHarness {
 			File target = new File(projectRoot, path);
 			IOUtil.pipe(new ByteArrayInputStream(content.getBytes("UTF8")), target);
 		}
-
+		
 		public void createType(String fqName, String sourceCode) throws Exception {
 			String sourceFile = sourceFolder()+"/"+fqName.replace('.', '/')+".java";
 			createFile(sourceFile, sourceCode);
@@ -98,7 +100,7 @@ public class ProjectsHarness {
 		this.fileObserver = fileObserver;
 	}
 
-	public IJavaProject project(ProjectType type, String name, ProjectCustomizer customizer, boolean build) throws Exception {
+	public IJavaProject project(ProjectType type, String name, boolean build, ProjectCustomizer customizer) throws Exception {
 		Tuple3<ProjectType, String, ProjectCustomizer> key = Tuples.of(type, name, customizer);
 		return cache.get(key, () -> {
 			Path baseProjectPath = getProjectPath(name);
@@ -122,7 +124,7 @@ public class ProjectsHarness {
 		}
 	}
 
-	public IJavaProject project(ProjectType type, String name, boolean build) throws Exception {
+	private IJavaProject project(ProjectType type, String name, boolean build) throws Exception {
 		return cache.get(type + "/" + name, () -> {
 			Path testProjectPath = getProjectPath(name);
 			return createProject(type, testProjectPath, build);
@@ -138,8 +140,12 @@ public class ProjectsHarness {
 		return Paths.get(resource);
 	}
 
+	public MavenJavaProject mavenProject(String name, boolean build, ProjectCustomizer customizer) throws Exception {
+		return (MavenJavaProject) project(ProjectType.MAVEN, name, build, customizer);
+	}
+
 	public MavenJavaProject mavenProject(String name, ProjectCustomizer customizer) throws Exception {
-		return (MavenJavaProject) project(ProjectType.MAVEN, name, customizer, true);
+		return (MavenJavaProject) project(ProjectType.MAVEN, name, true, customizer);
 	}
 
 	public MavenJavaProject mavenProject(String name) throws Exception {

--- a/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-request-mapping-symbols/src/main/java/org/test/PingConstantRequestMapping.java
+++ b/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-request-mapping-symbols/src/main/java/org/test/PingConstantRequestMapping.java
@@ -1,0 +1,15 @@
+package org.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class PingConstantRequestMapping {
+
+	public final static String PING = "/ping";
+	
+	@GetMapping(PongConstantRequestMapping.PONG)
+	public String hello() {
+		return "oy?";
+	}
+
+	
+}

--- a/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-request-mapping-symbols/src/main/java/org/test/PongConstantRequestMapping.java
+++ b/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-request-mapping-symbols/src/main/java/org/test/PongConstantRequestMapping.java
@@ -1,0 +1,14 @@
+package org.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class PongConstantRequestMapping {
+
+	public static final String PONG="/pong";
+	
+	@GetMapping(PingConstantRequestMapping.PING)
+	public String hello() {
+		return "oy?";
+	}
+
+}


### PR DESCRIPTION
@martinlippert I got something working that handles 'symbol' dependencies. 

I would welcome feedback before merging to master.

I sill need to figure out how to add tests for the dependency tracking. I.e. to test scenario where one file depends on another, other file is changed and then the symbols from the first file should update.

(Note: already added tests for the 'on disk cache' support. But that isnt really enough since it doesn't actually test the logic of the dependency data is discovered and used, only how it gets stored). 

I'll continue working on this tomorrow. Priority one will be to add a few tests for the depenency discovery and use. There's also a couple more optimisations that re left as //TODO in the code, which I might think about (though for now I think my priority is first on making sure it works correctly without these optimisations).

Synopsis of how this works:

1) while scanning a file, we keep track of when data is read from a ITYpeBiding. So for example, when we read a constant from a type 'Foo' then a 'dependency' on type 'Foo' is recorded for the current file.

2) during scanning of a file we keep track also of 'scanned types'.

3) at the end of a single-file scan, we check whether the 'scanned types' are dependencies of other scanned files. If yes, then all these files are considered 'affected' and we trigger a scan for them as well.

4) Step 3 is repeated until no additional files get scanned (this is guaranteed to terminate because we keep track of which files have already been scanned and so we never scan the same file twice.