### PR TITLE
Remove prerequisites from Maven pom files

### DIFF
--- a/eclipse-distribution/pom.xml
+++ b/eclipse-distribution/pom.xml
@@ -15,10 +15,6 @@
 	<url>https://spring.io/tools</url>
 	<inceptionYear>2007</inceptionYear>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License v1.0</name>

--- a/eclipse-language-servers/pom.xml
+++ b/eclipse-language-servers/pom.xml
@@ -15,10 +15,6 @@
 	<url>https://spring.io/tools</url>
 	<inceptionYear>2007</inceptionYear>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License v1.0</name>

--- a/headless-services/jdt-ls-extension/pom.xml
+++ b/headless-services/jdt-ls-extension/pom.xml
@@ -17,10 +17,6 @@
 	<url>https://spring.io/tools</url>
 	<inceptionYear>2007</inceptionYear>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<licenses>
 		<license>
 			<name>Eclipse Public License v1.0</name>


### PR DESCRIPTION
I stumbled upon the prerequisites section in Maven while trying to build sts4 (which I didn't success with). Prerequisites should not be used for Maven 3 and is only valid for Maven plugins. It usually results in warnings while building a project.

The maven-enforcer-plugin can be used to enforce a Maven version.