### PR TITLE
Fix concourse task schema

### DIFF
--- a/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
+++ b/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
@@ -284,7 +284,7 @@ public class PipelineYmlSchema implements YamlSchema {
 		addProp(task, "caches", f.yseq(cache));
 		addProp(task, "outputs", f.yseq(t_output));
 		addProp(task, "run", t_command).isRequired(true);
-		addProp(task, "params", t_string_params);
+		addProp(task, "params", t_params);
 		task.require(Constraints.schemaContextAware((DynamicSchemaContext dc) -> {
 			LanguageId languageId = dc.getDocument().getLanguageId();
 			if (LanguageId.CONCOURSE_PIPELINE.equals(languageId)) {

--- a/headless-services/concourse-language-server/src/test/java/org/springframework/ide/vscode/concourse/ConcourseEditorTest.java
+++ b/headless-services/concourse-language-server/src/test/java/org/springframework/ide/vscode/concourse/ConcourseEditorTest.java
@@ -495,7 +495,7 @@ public class ConcourseEditorTest {
 		editor.assertHoverContains("tags", "Any step can be directed at a pool of workers");
 		editor.assertHoverContains("timeout", "amount of time to limit the step's execution");
 	}
-	
+
 	@Test
 	public void taskVarsReconcile() throws Exception {
 		Editor editor;
@@ -3441,6 +3441,34 @@ public class ConcourseEditorTest {
 		);
 	}
 
+	@Test
+	public void taskWithYamlParams() throws Exception {
+		Editor editor;
+		
+		editor = harness.newEditor(LanguageId.CONCOURSE_TASK,
+			"---\n" +
+			"platform: linux\n" +
+			"image_resource:\n" +
+			"  type: docker-image\n" +
+			"  source:\n" +
+			"    repository: czero/platform-automation\n" +
+			"params:\n" +
+			"  DEBUG: false\n" +
+			"  VCENTER_URL: \n" +
+			"  VCENTER_INSECURE: true\n" +
+			"  NODE_COUNT: 4\n" +
+			"  IDRAC_IPS:\n" +
+			"    - 1.1.1.1\n" +
+			"    - 2.2.2.2\n" +
+			"inputs:\n" +
+			"  - name: pipeline\n" +
+			"run:\n" +
+			"  path: pipeline/tasks/re-image-hosts/task.sh\n"
+			
+		);
+		editor.assertProblems(/*NONE*/);
+	}
+	
 	@Test public void reconcileTaskFileToplevelProperties() throws Exception {
 		Editor editor;
 


### PR DESCRIPTION
Currently the language server throws an error like
"Expected string, got sequence" when you use yaml
as a default for a parameter in a task yaml.
See added test for an example that triggers the
behavior.