### PR TITLE
Add support for async completions in 4.15

### DIFF
--- a/eclipse-language-servers/org.springframework.tooling.boot.ls/plugin.xml
+++ b/eclipse-language-servers/org.springframework.tooling.boot.ls/plugin.xml
@@ -63,7 +63,8 @@
             activate="true"
             categoryId="org.eclipse.jdt.ui.defaultProposalCategory"
             class="org.springframework.tooling.boot.ls.jdt.SpringBootJavaCompletionProposalComputer"
-            needsSortingAfterFiltering="false">
+            needsSortingAfterFiltering="false"
+            requiresUIThread="false">
       </javaCompletionProposalComputer>
    </extension>
    


### PR DESCRIPTION
Marked the SpringBootJavaCompletionProposalComputer as requiresUIThread
= false so that the completions can be run asyncly.

This will make the new java async support to work even when STS4 tooling is installed.