### PR TITLE
Fix null reference when no JVM was found

### DIFF
--- a/nodejs-packages/jvm-launch-utils/src/jvm-util.ts
+++ b/nodejs-packages/jvm-launch-utils/src/jvm-util.ts
@@ -76,6 +76,9 @@ export function findJvm(javaHome?: string) : Promise<JVM | null> {
  */
 export function findJdk(javaHome?: string) : Promise<JVM | null> {
     return findJvm(javaHome).then(jvm => {
+        if(!jvm) {
+            return null;
+        }
         if (!jvm.isJdk()) {
             console.log("found jvm is not a JDK");
 


### PR DESCRIPTION
I got the same error as in #392 and tracked it back to the `findJdk` method. It calls `isJdk` on the resolved value from `findJvm`, which is null when no JVM was found.

I tested the change with the vs code plugin and got the expected "Couldn't locate java in $JAVA_HOME or $PATH" error message instead of the null reference.

I didn't test other projects using the jvm-launch-utils, because I don't have a setup for them.