### PR TITLE
Add display property to pipeline schema

### DIFF
--- a/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
+++ b/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
@@ -22,7 +22,6 @@ import org.springframework.ide.vscode.commons.util.MimeTypes;
 import org.springframework.ide.vscode.commons.util.PartialCollection;
 import org.springframework.ide.vscode.commons.util.Renderable;
 import org.springframework.ide.vscode.commons.util.Renderables;
-import org.springframework.ide.vscode.commons.util.StringUtil;
 import org.springframework.ide.vscode.commons.util.ValueParseException;
 import org.springframework.ide.vscode.commons.util.ValueParser;
 import org.springframework.ide.vscode.commons.util.ValueParsers;
@@ -37,7 +36,6 @@ import org.springframework.ide.vscode.commons.yaml.reconcile.YamlSchemaValuePars
 import org.springframework.ide.vscode.commons.yaml.reconcile.TypeBasedYamlHierarchicalSymbolHandler.HierarchicalDefType;
 import org.springframework.ide.vscode.commons.yaml.schema.BasicYValueHint;
 import org.springframework.ide.vscode.commons.yaml.schema.DynamicSchemaContext;
-import org.springframework.ide.vscode.commons.yaml.schema.SchemaContextAware;
 import org.springframework.ide.vscode.commons.yaml.schema.YType;
 import org.springframework.ide.vscode.commons.yaml.schema.YTypeFactory;
 import org.springframework.ide.vscode.commons.yaml.schema.YTypeFactory.AbstractType;
@@ -59,9 +57,7 @@ import org.springframework.ide.vscode.concourse.github.GithubValueParsers;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
 
-import com.fasterxml.jackson.databind.jsonschema.SchemaAware;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Kris De Volder

--- a/headless-services/concourse-language-server/src/main/resources/desc/Display/background_image.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/Display/background_image.md
@@ -1,0 +1,1 @@
+Allow users to specify a custom background image which is put at 30% opacity, grayscaled and blended into existing background. Must be an http, https, or relative URL.

--- a/headless-services/concourse-language-server/src/main/resources/desc/Pipeline/display.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/Pipeline/display.md
@@ -1,0 +1,8 @@
+Visual configurations for personalizing your pipeline (Concourse 6.6+ only)
+
+You may use this optional section to set a background image on your pipeline.
+
+A simple example looks like this:
+
+    display:
+      background_image: https://avatars1.githubusercontent.com/u/7809479?s=400&v=4

--- a/headless-services/concourse-language-server/src/test/java/org/springframework/ide/vscode/concourse/ConcourseEditorTest.java
+++ b/headless-services/concourse-language-server/src/test/java/org/springframework/ide/vscode/concourse/ConcourseEditorTest.java
@@ -184,6 +184,18 @@ public class ConcourseEditorTest {
 		);
 	}
 
+	@Test public void reconcileDisplayType() throws Exception {
+		Editor editor;
+		editor = harness.newEditor(
+				"display:\n" +
+				"  background_image: # <- bad\n"	
+		);
+
+		editor.assertProblems(
+				"^ # <- bad|String should not be empty"
+		);
+	}
+
 	@Test public void testReconcileCatchesParseError() throws Exception {
 		Editor editor = harness.newEditor(
 				"somemap: val\n"+
@@ -492,6 +504,17 @@ public class ConcourseEditorTest {
 		editor.assertHoverContains("on_success", "Any step can have `on_success` tacked onto it");
 		editor.assertHoverContains("ensure", "a second step to execute regardless of the result of the parent step");
 	}
+
+	@Test public void displayHovers() throws Exception {
+		Editor editor;
+		editor = harness.newEditor(
+				"display:\n" +
+				"  background_image: http://google.com/myimage.png\n"	
+		);
+
+		editor.assertHoverContains("background_image", "custom background image");
+	}
+
 
 	@Test
 	public void groupHovers() throws Exception {
@@ -819,6 +842,9 @@ public class ConcourseEditorTest {
 		Editor editor;
 		editor = harness.newEditor(CURSOR);
 		editor.assertCompletions(
+				"display:\n"+
+				"  background_image: <*>"
+				, // ---------------
 				"groups:\n" +
 				"- name: <*>"
 				, // --------------
@@ -890,6 +916,8 @@ public class ConcourseEditorTest {
 	@Test
 	public void topLevelHoverInfos() throws Exception {
 		Editor editor = harness.newEditor(
+			"display:\n" +
+			"  background_image: http://example.com/fakeimage.png\n" +
 			"resource_types:\n" +
 			"- name: s3-multi\n" +
 			"  type: docker-image\n" +
@@ -924,6 +952,7 @@ public class ConcourseEditorTest {
 		editor.assertHoverContains("resources", "A resource is any entity that can be checked for new versions");
 		editor.assertHoverContains("jobs", "At a high level, a job describes some actions to perform");
 		editor.assertHoverContains("groups", "A pipeline may optionally contain a section called `groups`");
+		editor.assertHoverContains("display", "set a background image on your pipeline");
 	}
 
 	@Test
@@ -4003,11 +4032,12 @@ public class ConcourseEditorTest {
 				//For the nested context:
 				"→ uri",
 				// For the top-level context:
+				"← display",
 				"← groups",
 				"← jobs",
 				"← resource_types",
 				"← - Resource Snippet",
-				// For the 'next job' context:
+				// For the 'next job' context
 				"← - name"
 		);
 
@@ -4255,6 +4285,7 @@ public class ConcourseEditorTest {
 				"- try",
 				"- aggregate",
 				//Dedented completions
+				"← display",
 				"← groups",
 				"← resource_types",
 				"← resources",
@@ -4711,6 +4742,7 @@ public class ConcourseEditorTest {
 				"<*>"
 		);
 		editor.assertCompletionLabels(
+				"display",
 				"groups",
 				"jobs",
 				"resource_types",


### PR DESCRIPTION
In Concourse 6.6, a feature was introduced to allow pipeline developers
to set custom background images to their pipelines. This commit adds
support for that field to the language server.