### PR TITLE
vscode-spring-boot: Auto connect to launched app

### DIFF
--- a/vscode-extensions/vscode-spring-boot/lib/Main.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/Main.ts
@@ -7,6 +7,7 @@ import * as commons from '@pivotal-tools/commons-vscode';
 import * as liveHoverUi from './live-hover-connect-ui';
 
 import {LanguageClient} from "vscode-languageclient/node";
+import { startDebugSupport } from './debug-config-provider';
 
 const PROPERTIES_LANGUAGE_ID = "spring-boot-properties";
 const YAML_LANGUAGE_ID = "spring-boot-properties-yaml";
@@ -77,6 +78,9 @@ export function activate(context: VSCode.ExtensionContext): Thenable<LanguageCli
         },
         highlightCodeLensSettingKey: 'boot-java.highlight-codelens.on'
     };
+
+    // Register launch config contributior to java debug launch to be able to connect to JMX
+    context.subscriptions.push(startDebugSupport());
 
     return commons.activate(options, context).then(client => {
         liveHoverUi.activate(client, options, context);

--- a/vscode-extensions/vscode-spring-boot/lib/debug-config-provider.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/debug-config-provider.ts
@@ -1,0 +1,97 @@
+import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, ProviderResult, WorkspaceFolder } from "vscode";
+import * as path from "path";
+import * as VSCode from "vscode";
+import { Disposable } from "vscode";
+import { ProcessCommandInfo } from "./live-hover-connect-ui";
+
+const JMX_VM_ARG = '-Dspring.jmx.enabled=true'
+const ADMIN_VM_ARG = '-Dspring.application.admin.enabled=true'
+
+class SpringBootDebugConfigProvider implements DebugConfigurationProvider {
+
+    resolveDebugConfigurationWithSubstitutedVariables(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+        if (isAutoConnect() && this.isActuatorOnClasspath(debugConfiguration)) {
+            if (debugConfiguration.vmArgs) {
+                if (debugConfiguration.vmArgs.indexOf(JMX_VM_ARG) < 0) {
+                    debugConfiguration.vmArgs += ` ${JMX_VM_ARG}`;
+                }
+                if (debugConfiguration.vmArgs.indexOf(ADMIN_VM_ARG) < 0) {
+                    debugConfiguration.vmArgs += ` ${ADMIN_VM_ARG}`;
+                }
+            } else {
+                debugConfiguration.vmArgs = `${JMX_VM_ARG} ${ADMIN_VM_ARG}`;
+            }
+        }
+        return debugConfiguration;
+    }
+
+    private isActuatorOnClasspath(debugConfiguration: DebugConfiguration): boolean {
+        if (Array.isArray(debugConfiguration.classPaths)) {
+            return !!debugConfiguration.classPaths.find(this.isActuatorJarFile);
+        }
+        return false;
+    }
+
+    private isActuatorJarFile(f: string): boolean {
+        const fileName = path.basename(f || "");
+        if (/^spring-boot-actuator-\d+\.\d+\.\d+(.*)?.jar$/.test(fileName)) {
+            return true;
+        }
+        return false;
+    }
+
+}
+
+export function startDebugSupport(): Disposable {
+    VSCode.debug.onDidStartDebugSession(handleDebugSessionStarted);
+    return VSCode.debug.registerDebugConfigurationProvider('java', new SpringBootDebugConfigProvider(), VSCode.DebugConfigurationProviderTriggerKind.Initial);
+}
+
+function isAutoConnect(): boolean {
+    return VSCode.workspace.getConfiguration("boot-java.live-information.automatic-tracking")?.get('on');
+}
+
+function handleDebugSessionStarted(e: VSCode.DebugSession): void {
+    if (e.configuration.type === 'java'
+        && isAutoConnect()
+        && e.configuration.vmArgs
+        && e.configuration.vmArgs.indexOf(JMX_VM_ARG) >= 0
+        && e.configuration.vmArgs.indexOf(ADMIN_VM_ARG) >= 0) {
+        attemptToConnect(e.configuration.mainClass, 5, 3000);
+    }
+}
+
+async function attemptToConnect(mainClass: string, attempts: number, interval: number) {
+    try {
+        const info = await attemptToFindProcess(mainClass, attempts, interval);
+        console.log(`Connecting to ${info.processKey}`)
+        await VSCode.commands.executeCommand(info.action, info);
+    } catch (e) {
+        VSCode.window.showErrorMessage(`Failed to automatically connect to Boot app process corresponding to ${mainClass}`);
+    }
+}
+
+function attemptToFindProcess(mainClass: string, attempts: number, interval: number): Promise<ProcessCommandInfo> {
+    return new Promise((resolve, reject) => {
+        const intervalHandle = setInterval(async () => {
+            try {
+                console.log(`Looking for launched java process corresponding to Boot app ${mainClass}. Attempts left ${attempts}.`);
+                const processData: ProcessCommandInfo[] = await VSCode.commands.executeCommand('sts/livedata/listProcesses');
+                const info = processData.find(pd => pd.processKey.endsWith(mainClass) && pd.action === 'sts/livedata/connect');
+                if (info) {
+                    clearInterval(intervalHandle);
+                    resolve(info);
+                }
+            } catch (e) {
+                // ignore
+            }
+            attempts--;
+            if (attempts === 0) {
+                clearInterval(intervalHandle);
+                // TODO: show error message
+                const msg = `Cannot find Boot application process corresponding to launched ${mainClass}`;
+                reject();
+            }
+        }, interval);
+    });
+}

--- a/vscode-extensions/vscode-spring-boot/lib/live-hover-connect-ui.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/live-hover-connect-ui.ts
@@ -4,7 +4,7 @@ import * as VSCode from 'vscode';
 import { LanguageClient } from "vscode-languageclient/node";
 import { ActivatorOptions } from '@pivotal-tools/commons-vscode';
 
-interface ProcessCommandInfo {
+export interface ProcessCommandInfo {
     processKey : string;
 	label: string;
 	action: string

--- a/vscode-extensions/vscode-spring-boot/package.json
+++ b/vscode-extensions/vscode-spring-boot/package.json
@@ -29,7 +29,8 @@
     "onLanguage:spring-boot-properties",
     "onLanguage:spring-boot-properties-yaml",
     "onLanguage:java",
-    "onLanguage:xml"
+    "onLanguage:xml",
+    "onDebugResolve:java"
   ],
   "contributes": {
     "javaExtensions": [


### PR DESCRIPTION
@martinlippert This is my attempt to connect to the launched boot app in VSCode similarly to the way we connect to it in the STS4 Eclipse. There are a few rough edges:
- `boot-java.live-information.automatic-tracking.on` is set? Then jmx boot properties are always added to the config.
- no indication of when the spring boot app is fully started as well as not sure how to get pid. Therefore, connection is list java processes command, find the process with the same named main class and attempt to connect to it.

Addresses #733 