### PR TITLE
add extension APIs to get live data

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorService.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorService.java
@@ -110,6 +110,10 @@ public class SpringProcessConnectorService {
 		}
 	}
 
+	public SpringProcessLiveData getLiveData(String processKey) {
+		return this.liveDataProvider.getCurrent(processKey);
+	}
+
 	public void disconnectProcess(String processKey) {
 		log.info("disconnect from process: " + processKey);
 

--- a/vscode-extensions/vscode-spring-boot/lib/Main.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/Main.ts
@@ -9,6 +9,8 @@ import * as liveHoverUi from './live-hover-connect-ui';
 
 import {LanguageClient} from "vscode-languageclient/node";
 import { startDebugSupport } from './debug-config-provider';
+import { ApiManager } from "./apiManager";
+import { ExtensionAPI } from "./api";
 
 const PROPERTIES_LANGUAGE_ID = "spring-boot-properties";
 const YAML_LANGUAGE_ID = "spring-boot-properties-yaml";
@@ -18,7 +20,7 @@ const XML_LANGUAGE_ID = "xml";
 const NEVER_SHOW_AGAIN = "Do not show again";
 
 /** Called when extension is activated */
-export function activate(context: VSCode.ExtensionContext): Thenable<LanguageClient> {
+export function activate(context: VSCode.ExtensionContext): Thenable<ExtensionAPI> {
 
     // registerPipelineGenerator(context);
     let options : commons.ActivatorOptions = {
@@ -109,6 +111,6 @@ export function activate(context: VSCode.ExtensionContext): Thenable<LanguageCli
 
     return commons.activate(options, context).then(client => {
         liveHoverUi.activate(client, options, context);
-        return client;
+        return new ApiManager(client).api;
     });
 }

--- a/vscode-extensions/vscode-spring-boot/lib/api.d.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/api.d.ts
@@ -1,0 +1,42 @@
+import { Event } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+
+export interface ExtensionAPI {
+    readonly client: LanguageClient;
+
+    /**
+     * An event which fires on live process is connected. Payload is processKey.
+     */
+    readonly onDidLiveProcessConnect: Event<string>
+
+    /**
+     * An event which fires on live process is disconnected. Payload is processKey.
+     */
+    readonly onDidLiveProcessDisconnect: Event<string>
+
+    /**
+     * A command to get live process data.
+     */
+    readonly getLiveProcessData: (query: SimpleQuery | BeansQuery) => Promise<any>
+
+}
+
+interface LiveProcessDataQuery {
+    /**
+     * unique identifier of a connected live process.
+     */
+    processKey: string;
+}
+
+interface SimpleQuery extends LiveProcessDataQuery {
+    endpoint: "mappings" | "contextPath" | "port" | "properties";
+}
+
+interface BeansQuery extends LiveProcessDataQuery {
+    endpoint: "beans";
+    /**
+     * if provided, return corresponding beans via name.
+     */
+    beanName?: string;
+    dependingOn?: string;
+}

--- a/vscode-extensions/vscode-spring-boot/lib/apiManager.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/apiManager.ts
@@ -1,0 +1,31 @@
+import { commands, Uri } from "vscode";
+import { Emitter, LanguageClient } from "vscode-languageclient/node";
+import { ExtensionAPI } from "./api";
+import { LiveProcessConnectedNotification, LiveProcessDisconnectedNotification } from "./notification";
+
+export class ApiManager {
+    public api: ExtensionAPI;
+    private onDidLiveProcessConnectEmitter: Emitter<string> = new Emitter<string>();
+    private onDidLiveProcessDisconnectEmitter: Emitter<string> = new Emitter<string>();
+
+    public constructor(private client: LanguageClient) {
+        const onDidLiveProcessConnect = this.onDidLiveProcessConnectEmitter.event;
+        const onDidLiveProcessDisconnect = this.onDidLiveProcessDisconnectEmitter.event;
+
+        const COMMAND_LIVEDATA_GET = "sts/livedata/get";
+        const getLiveProcessData = async (query) => {
+            await commands.executeCommand(COMMAND_LIVEDATA_GET, query);
+        }
+
+        // TODO: STS server should send corresponding notification back.
+        client.onNotification(LiveProcessConnectedNotification.type, (processKey: string) => this.onDidLiveProcessConnectEmitter.fire(processKey));
+        client.onNotification(LiveProcessDisconnectedNotification.type, (processKey: string) => this.onDidLiveProcessDisconnectEmitter.fire(processKey));
+
+        this.api = {
+            client,
+            onDidLiveProcessConnect,
+            onDidLiveProcessDisconnect,
+            getLiveProcessData
+        };
+    }
+}

--- a/vscode-extensions/vscode-spring-boot/lib/notification.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/notification.ts
@@ -1,0 +1,9 @@
+import { NotificationType } from "vscode-languageclient";
+
+export namespace LiveProcessConnectedNotification {
+	export const type = new NotificationType<string>('sts/liveprocess/connected');
+}
+
+export namespace LiveProcessDisconnectedNotification {
+	export const type = new NotificationType<string>('sts/liveprocess/disconnected');
+}


### PR DESCRIPTION
Currently sts-vscode expose its language client to other extensions. In this PR, besides the language client instance, I also expose some APIs for downstream extension to easily get live process data. (see `api.d.ts`)

Downstream extension can now listen to events when live connection is connected/disconnected, and decides to fetch live data using the API.
