### PR TITLE
sts-vscode: fix extension api implementation

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessCommandHandler.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessCommandHandler.java
@@ -205,10 +205,10 @@ public class SpringProcessCommandHandler {
 	
 	private CompletableFuture<Object> get(ExecuteCommandParams params) {
 		String processKey = getProcessKey(params);
-		String dataKey = getArgumentByKey(params, "dataKey");
+		String endpoint = getArgumentByKey(params, "endpoint");
 		if (processKey != null) {
 			SpringProcessLiveData data = connectorService.getLiveData(processKey);
-			switch(dataKey) {
+			switch(endpoint) {
 				case "properties": {
 					return CompletableFuture.completedFuture(data.getLiveProperties());
 				}

--- a/vscode-extensions/vscode-spring-boot/lib/apiManager.ts
+++ b/vscode-extensions/vscode-spring-boot/lib/apiManager.ts
@@ -9,17 +9,16 @@ export class ApiManager {
     private onDidLiveProcessDisconnectEmitter: Emitter<string> = new Emitter<string>();
     private onDidLiveProcessUpdateEmitter: Emitter<string> = new Emitter<string>();
 
-    public constructor(private client: LanguageClient) {
+    public constructor(client: LanguageClient) {
         const onDidLiveProcessConnect = this.onDidLiveProcessConnectEmitter.event;
         const onDidLiveProcessDisconnect = this.onDidLiveProcessDisconnectEmitter.event;
         const onDidLiveProcessUpdate = this.onDidLiveProcessUpdateEmitter.event;
 
         const COMMAND_LIVEDATA_GET = "sts/livedata/get";
         const getLiveProcessData = async (query) => {
-            await commands.executeCommand(COMMAND_LIVEDATA_GET, query);
+            return await commands.executeCommand(COMMAND_LIVEDATA_GET, query);
         }
 
-        // TODO: STS server should send corresponding notification back.
         client.onNotification(LiveProcessConnectedNotification.type, (processKey: string) => this.onDidLiveProcessConnectEmitter.fire(processKey));
         client.onNotification(LiveProcessDisconnectedNotification.type, (processKey: string) => this.onDidLiveProcessDisconnectEmitter.fire(processKey));
         client.onNotification(LiveProcessUpdatedNotification.type, (processKey: string) => this.onDidLiveProcessUpdateEmitter.fire(processKey));


### PR DESCRIPTION
A patch for PR #751, otherwise it won't work. Fixing two problems:
- inconsistent name of argument between API definition and implmentation.
- didn't return the result in `getLiveProcessData` 




