### PR TITLE
Update Concourse registry-image schema

### DIFF
--- a/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
+++ b/headless-services/concourse-language-server/src/main/java/org/springframework/ide/vscode/concourse/PipelineYmlSchema.java
@@ -62,6 +62,7 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * @author Kris De Volder
+ * @author LukeBalizet
  */
 public class PipelineYmlSchema implements YamlSchema {
 
@@ -674,10 +675,27 @@ public class PipelineYmlSchema implements YamlSchema {
 		{
 			AbstractType source = f.ybean("RegistryImageSource");
 			addProp(source, "repository", t_ne_string).isPrimary(true);
+			addProp(source, "insecure", t_boolean);
 			addProp(source, "tag", t_ne_string);
+			addProp(source, "variant", t_ne_string);
+			addProp(source, "semver_constraint", t_ne_string);
 			addProp(source, "username", t_ne_string);
 			addProp(source, "password", t_ne_string);
+			addProp(source, "aws_access_key_id", t_ne_string);
+			addProp(source, "aws_secret_access_key", t_ne_string);
+			addProp(source, "aws_session_token", t_ne_string);
+			addProp(source, "aws_region", t_ne_string);
+			addProp(source, "aws_role_arn", t_ne_string);
+			addProp(source, "aws_role_arns", t_strings);
 			addProp(source, "debug", t_boolean);
+			{
+				AbstractType registry_mirror = f.ybean("RegistryMirror");
+				addProp(registry_mirror, "host", t_ne_string).isPrimary(true);
+				addProp(registry_mirror, "username", t_ne_string);
+				addProp(registry_mirror, "password", t_ne_string);
+
+				addProp(source, "registry_mirror", registry_mirror);
+			}
 			{
 				AbstractType contentTrust = f.ybean("RegistryImageContentTrust");
 				addProp(contentTrust, "server", t_ne_string);
@@ -689,6 +707,7 @@ public class PipelineYmlSchema implements YamlSchema {
 				
 				addProp(source, "content_trust", contentTrust);
 			}
+			addProp(source, "ca_certs", t_strings);
 			
 			AbstractType get = f.ybean("RegistryImageGetParams");
 			addProp(get, "format", f.yenum("RegistryImageFormat", "rootfs", "oci"));
@@ -696,6 +715,8 @@ public class PipelineYmlSchema implements YamlSchema {
 			
 			AbstractType put = f.ybean("RegistryImagePutParams");
 			addProp(put, "image", t_ne_string).isPrimary(true);
+			addProp(put, "version", t_ne_string);
+			addProp(get, "bump_aliases", t_boolean);
 			addProp(put, "additional_tags", t_ne_string);
 
 			resourceTypes.def("registry-image", source, get, put);

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImagePutParams/bump_aliases.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImagePutParams/bump_aliases.md
@@ -1,0 +1,11 @@
+*Optional. Default `false`.* When set to `true` and `version` is specified
+automatically bump alias tags for the version. For example, when pushing version
+`1.2.3`, push the same image to the following tags:
+- `1.2`, if 1.2.3 is the latest version of 1.2.x.
+- `1`, if 1.2.3 is the latest version of 1.x.
+- `latest`, if 1.2.3 is the latest version overall.
+
+If `variant` is configured as `foo`, push the same image to the following tags:
+- `1.2-foo`, if 1.2.3 is the latest version of 1.2.x with `foo`.
+- `1-foo`, if 1.2.3 is the latest version of 1.x with `foo`.
+- `foo`, if 1.2.3 is the latest version overall for `foo`

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImagePutParams/version.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImagePutParams/version.md
@@ -1,0 +1,1 @@
+*Optional.* A version number to use as a tag.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_access_key_id.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_access_key_id.md
@@ -1,0 +1,1 @@
+*Optional*. The access key ID to use for authenticating with ECR.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_region.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_region.md
@@ -1,0 +1,4 @@
+*Optional*. The region to use for
+  accessing ECR. This is required if you are using ECR. This region
+  will help determine the full repository URL you are accessing
+  (e.g., `012345678910.dkr.ecr.us-east-1.amazonaws.com`)

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_role_arn.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_role_arn.md
@@ -1,0 +1,3 @@
+*Optional*. If set, then this role will
+  be assumed before authenticating to ECR. An error will occur if
+  `aws_role_arns` is also specified. This is kept for backward compatibility.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_role_arns.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_role_arns.md
@@ -1,0 +1,4 @@
+*Optional*. An array of AWS IAM roles.
+  If set, these roles will be assumed in the specified order before
+  authenticating to ECR. An error will occur if `aws_role_arn`
+  is also specified.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_secret_access_key .md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_secret_access_key .md
@@ -1,0 +1,1 @@
+*Optional*. The secret access key to use for authenticating with ECR.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_session_token.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/aws_session_token.md
@@ -1,0 +1,2 @@
+*Optional*. The session token to use for authenticating with
+  STS credentials with ECR.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/ca_certs.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/ca_certs.md
@@ -1,0 +1,15 @@
+*Optional*. An array of PEM-encoded CA certificates. Example:
+```yaml
+ca_certs:
+- |
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+- |
+  -----BEGIN CERTIFICATE-----
+  ...
+  -----END CERTIFICATE-----
+``` 
+Each entry specifies the x509 CA certificate for the trusted docker registry.
+This is used to validate the certificate of the docker registry when the
+registry's certificate is signed by a custom authority (or itself).

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/insecure.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/insecure.md
@@ -1,0 +1,1 @@
+*Optional. Default `false`.* Allow insecure registry.

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/semver_constraint.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/semver_constraint.md
@@ -1,0 +1,7 @@
+*Optional.* Constrain the returned semver
+  tags according to a semver constraint, e.g.
+  `"~1.2.x"`, `">= 1.2 < 3.0.0 || >= 4.2.3"`. Follows the rules outlined in
+  [https://github.com/Masterminds/semver#checking-version-constraints](https://github.com/Masterminds/semver#checking-version-constraints)
+
+
+  

--- a/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/variant.md
+++ b/headless-services/concourse-language-server/src/main/resources/desc/RegistryImageSource/variant.md
@@ -1,0 +1,6 @@
+*Optional.* Detect only tags matching this
+  variant suffix, and push version tags with this suffix applied. For example,
+  a value of `stretch` would be used for tags like `1.2.3-stretch`. This is
+  typically used *without* `tag` - if it is set, this value will only used for
+  pushing, not checking.
+  


### PR DESCRIPTION
Update Concourse `registry-image` resource schema to match [`concourse/registry-image-resource`](https://github.com/concourse/registry-image-resource/blob/671c7bcae57f48111cd7fd755eea7b72553fb44f/README.md)

**Sources:**
- [Source Configuration](https://github.com/concourse/registry-image-resource/blob/671c7bcae57f48111cd7fd755eea7b72553fb44f/README.md#source-configuration)
- [`get` Step `params`](https://github.com/concourse/registry-image-resource/blob/671c7bcae57f48111cd7fd755eea7b72553fb44f/README.md#get-step-params)
- [`put` Steps `params`](https://github.com/concourse/registry-image-resource/blob/671c7bcae57f48111cd7fd755eea7b72553fb44f/README.md#put-steps-params)