### PR TITLE
vscode-concourse: support both .yml and .yaml files

### DIFF
--- a/vscode-extensions/vscode-concourse/README.md
+++ b/vscode-extensions/vscode-concourse/README.md
@@ -8,8 +8,8 @@ for editing [Concourse](https://concourse-ci.org/) Pipeline and Task configurati
 The Concourse editor automatically activates when the name of the  `.yml` file you are editing 
 follows a certain pattern:
 
-  - `**/*pipeline*.yml` | `**/pipeline/*.yml` : activates support for editing pipelines
-  - `**/ci/**/tasks/*.yml` | `**/*task.yml` : activates support for editing tasks.
+  - `**/*pipeline*.yml` | `**/pipeline/*.yml` | `**/*pipeline*.yaml` | `**/pipeline/*.yaml`: activates support for editing pipelines
+  - `**/ci/**/tasks/*.yml` | `**/*task.yml` |  `**/ci/**/tasks/*.yaml` | `**/*task.yaml` : activates support for editing tasks.
   
 You can also define your own patterns and map them to the language-ids `concourse-pipeline-yaml` 
 or `concourse-task-yaml` by defining `files.associations` in workspace settings. 

--- a/vscode-extensions/vscode-concourse/package.json
+++ b/vscode-extensions/vscode-concourse/package.json
@@ -70,7 +70,9 @@
         ],
         "filenamePatterns": [
           "*pipeline*.yml",
-          "**/pipeline/*.yml"
+          "**/pipeline/*.yml",
+          "*pipeline*.yaml",
+          "**/pipeline/*.yaml"
         ],
         "firstLine": "^#(\\s)*pipeline(\\s)*",
         "configuration": "./yaml-support/language-configuration.json"
@@ -84,7 +86,11 @@
           "**/ci/*task.yml",
           "**/ci/**/tasks/*.yml",
           "**/concourse/*task.yml",
-          "**/concourse/**/tasks/*.yml"
+          "**/concourse/**/tasks/*.yml",
+          "**/ci/*task.yaml",
+          "**/ci/**/tasks/*.yaml",
+          "**/concourse/*task.yaml",
+          "**/concourse/**/tasks/*.yaml"
         ],
         "firstLine": "^#(\\s)*task(\\s)*",
         "configuration": "./yaml-support/language-configuration.json"


### PR DESCRIPTION
Some people write .yml, some write .yaml. Both pipeline.yml and pipeline.yaml behave the same way, so highlight them both as Concourse pipelines & tasks.

Added because my organization uses pipeline.yaml consistently, so probably other people do too.

## Reproduction

1. create a file `~/tmp/pipeline.yaml`
2. run extension
3. open terminal
4. `code ~/tmp/pipeline.yaml`
5. look at the bottom to see if it says "Concourse Pipeline" or "YAML"

| before | after |
| --- | --- |
| <img width="731" alt="image" src="https://user-images.githubusercontent.com/3344958/189281019-147ef48a-2cb5-4578-a23b-d7b9280af7b8.png"> | <img width="731" alt="image" src="https://user-images.githubusercontent.com/3344958/189281005-7abb005d-91d4-4c8b-96f4-4a3116cc72d2.png"> |


