### PR TITLE
Factor out static methods for Spring Data repository completions

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/FindByCompletionProposal.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/FindByCompletionProposal.java
@@ -39,6 +39,24 @@ public class FindByCompletionProposal implements ICompletionProposal {
 		this.filter = filter;
 	}
 
+	public static ICompletionProposal createProposal(int offset, CompletionItemKind completionItemKind, String prefix, String label, String completion) {
+		DocumentEdits edits = new DocumentEdits(null, false);
+		String filter = label;
+		if (prefix != null && label.startsWith(prefix)) {
+			edits.replace(offset - prefix.length(), offset, completion);
+		}
+		else if (prefix != null && completion.startsWith(prefix)) {
+			edits.replace(offset - prefix.length(), offset, completion);
+			filter = completion;
+		}
+		else {
+			edits.insert(offset, completion);
+		}
+
+		DocumentEdits additionalEdits = new DocumentEdits(null, false);
+		return new FindByCompletionProposal(label, completionItemKind, edits, null, null, Optional.of(additionalEdits), filter);
+	}
+
 	@Override
 	public String getLabel() {
 		return label;

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryCompletionProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryCompletionProvider.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.vscode.boot.java.data.providers;
+
+import java.util.Collection;
+
+import org.springframework.ide.vscode.boot.java.data.DataRepositoryDefinition;
+import org.springframework.ide.vscode.commons.languageserver.completion.ICompletionProposal;
+import org.springframework.ide.vscode.commons.util.text.IDocument;
+
+/**
+ * Responsible for creating proposals related to Spring Data repositories.
+ * @author danthe1st
+ */
+public interface DataRepositoryCompletionProvider {
+
+	void addProposals(Collection<ICompletionProposal> completions, IDocument doc, int offset, String prefix, DataRepositoryDefinition repo);
+
+}

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryQueryStartCompletionProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryQueryStartCompletionProvider.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.vscode.boot.java.data.providers;
+
+import java.util.Collection;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.springframework.ide.vscode.boot.java.data.DataRepositoryDefinition;
+import org.springframework.ide.vscode.boot.java.data.FindByCompletionProposal;
+import org.springframework.ide.vscode.boot.java.data.providers.prefixsensitive.DataRepositoryPrefixSensitiveCompletionProvider;
+import org.springframework.ide.vscode.commons.languageserver.completion.ICompletionProposal;
+import org.springframework.ide.vscode.commons.util.BadLocationException;
+import org.springframework.ide.vscode.commons.util.text.IDocument;
+
+/**
+ * This class creates text roposals for query method subjects, e.g. {@code countBy}.
+ * @author danthe1st
+ */
+public class DataRepositoryQueryStartCompletionProvider implements DataRepositoryCompletionProvider{
+
+	@Override
+	public void addProposals(Collection<ICompletionProposal> completions, IDocument doc, int offset, String prefix, DataRepositoryDefinition repo) {
+		String localPrefix = DataRepositoryPrefixSensitiveCompletionProvider.findLastJavaIdentifierPart(prefix);
+		for(QueryMethodSubject queryMethodSubject : QueryMethodSubject.QUERY_METHOD_SUBJECTS){
+			String toInsert = queryMethodSubject.key() + "By";
+			if(prefix == null || toInsert.startsWith(localPrefix)||isOffsetAfterWhitespace(doc, offset)) {
+				completions.add(FindByCompletionProposal.createProposal(offset, CompletionItemKind.Text, prefix, toInsert, toInsert));
+			}
+		}
+	}
+
+	private boolean isOffsetAfterWhitespace(IDocument doc, int offset) {
+		try {
+			return offset > 0 && Character.isWhitespace(doc.getChar(offset-1));
+		}catch (BadLocationException e) {
+			return false;
+		}
+	}
+
+}

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryStandardCompletionProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/DataRepositoryStandardCompletionProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.vscode.boot.java.data.providers;
+
+import java.util.Collection;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.springframework.ide.vscode.boot.java.data.DataRepositoryDefinition;
+import org.springframework.ide.vscode.boot.java.data.DomainProperty;
+import org.springframework.ide.vscode.boot.java.data.DomainType;
+import org.springframework.ide.vscode.boot.java.data.FindByCompletionProposal;
+import org.springframework.ide.vscode.commons.languageserver.completion.ICompletionProposal;
+import org.springframework.ide.vscode.commons.util.text.IDocument;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides content assist proposals for querying by a single attribute in Spring Data repositories.
+ * @author Martin Lippert
+ */
+@Component
+public class DataRepositoryStandardCompletionProvider implements DataRepositoryCompletionProvider {
+
+	public void addProposals(Collection<ICompletionProposal> completions, IDocument doc, int offset, String prefix, DataRepositoryDefinition repo) {
+		DomainType domainType = repo.getDomainType();
+		DomainProperty[] properties = domainType.getProperties();
+		for (DomainProperty property : properties) {
+			completions.add(generateCompletionProposal(offset, prefix, repo, property));
+		}
+	}
+
+	private ICompletionProposal generateCompletionProposal(int offset, String prefix, DataRepositoryDefinition repoDef, DomainProperty domainProperty) {
+		StringBuilder label = new StringBuilder();
+		label.append("findBy");
+		label.append(StringUtils.capitalize(domainProperty.getName()));
+		label.append("(");
+		label.append(domainProperty.getType().getSimpleName());
+		label.append(" ");
+		label.append(StringUtils.uncapitalize(domainProperty.getName()));
+		label.append(");");
+
+		StringBuilder completion = new StringBuilder();
+		completion.append("List<");
+		completion.append(repoDef.getDomainType().getSimpleName());
+		completion.append("> findBy");
+		completion.append(StringUtils.capitalize(domainProperty.getName()));
+		completion.append("(");
+		completion.append(domainProperty.getType().getSimpleName());
+		completion.append(" ");
+		completion.append(StringUtils.uncapitalize(domainProperty.getName()));
+		completion.append(");");
+
+		return FindByCompletionProposal.createProposal(offset, CompletionItemKind.Method, prefix, label.toString(), completion.toString());
+	}
+}

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/QueryMethodSubject.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/QueryMethodSubject.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Pivotal, Inc. - initial API and implementation
  *******************************************************************************/
-package org.springframework.ide.vscode.boot.java.data;
+package org.springframework.ide.vscode.boot.java.data.providers;
 
 import java.util.List;
 
@@ -18,10 +18,10 @@ import java.util.List;
  * See https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#appendix.query.method.subject
  * @author danthe1st
  */
-record QueryMethodSubject(
+public record QueryMethodSubject(
 		String key, String returnType, boolean isTyped) {
 
-	static final List<QueryMethodSubject> QUERY_METHOD_SUBJECTS = List.of(
+	public static final List<QueryMethodSubject> QUERY_METHOD_SUBJECTS = List.of(
 			QueryMethodSubject.createCollectionSubject("find", "List"),
 			QueryMethodSubject.createCollectionSubject("read", "List"),
 			QueryMethodSubject.createCollectionSubject("get", "List"),

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodKeywordType.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodKeywordType.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Pivotal, Inc. - initial API and implementation
  *******************************************************************************/
-package org.springframework.ide.vscode.boot.java.data;
+package org.springframework.ide.vscode.boot.java.data.providers.prefixsensitive;
 
 /**
  * Types of predicate keywords Spring JPA repository method names

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodNameParseResult.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodNameParseResult.java
@@ -8,13 +8,15 @@
  * Contributors:
  *     Pivotal, Inc. - initial API and implementation
  *******************************************************************************/
-package org.springframework.ide.vscode.boot.java.data;
+package org.springframework.ide.vscode.boot.java.data.providers.prefixsensitive;
 
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.ide.vscode.boot.java.data.providers.QueryMethodSubject;
+
 /**
- * Represents the result of parsing a Spring JPA repository query method
+ * Represents the result of parsing a Spring Data repository query method
  * @author danthe1st
  */
 record DataRepositoryMethodNameParseResult(

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodParser.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodParser.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Pivotal, Inc. - initial API and implementation
  *******************************************************************************/
-package org.springframework.ide.vscode.boot.java.data;
+package org.springframework.ide.vscode.boot.java.data.providers.prefixsensitive;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -17,6 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.springframework.ide.vscode.boot.java.data.DataRepositoryDefinition;
+import org.springframework.ide.vscode.boot.java.data.DomainProperty;
+import org.springframework.ide.vscode.boot.java.data.providers.QueryMethodSubject;
 
 /**
  * Class responsible for parsing Spring JPA Repository query methods.

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/QueryPredicateKeywordInfo.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/QueryPredicateKeywordInfo.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Pivotal, Inc. - initial API and implementation
  *******************************************************************************/
-package org.springframework.ide.vscode.boot.java.data;
+package org.springframework.ide.vscode.boot.java.data.providers.prefixsensitive;
 
 import java.util.List;
 


### PR DESCRIPTION
This PR factors out Spring Data repository completions into multiple classes as suggested in https://github.com/spring-projects/sts4/pull/981#issuecomment-1439205837.

Instances of these classes are stored in a `List` which is instantiated in the constructor of `DataRepositoryCompletionProcessor`.

For now, I have not used Spring Beans for this as it seems that only the package `org.springframework.ide.vscode.boot.app` is scanned for components.

Alternatively, corresponding Spring beans could be defined in `BootJavaCompletionEngineConfigurer` or similar.

This PR should not change any functionality.