### PR TITLE
completions for predicate keywords in Spring Data repositories

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodNameParseResult.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodNameParseResult.java
@@ -33,9 +33,9 @@ record DataRepositoryMethodNameParseResult(
 		 */
 		boolean performFullCompletion,
 		/**
-		 * the last entered word, which completion options should be used for completing the expression.
+		 * the last entered word (if it is not a keyword), which completion options should be used for completing the expression.
 		 *
-		 * e.g. {@code First} in {@code findByFirst} which could be completed to {@code findByFirstName}
+		 * e.g. {@code First} in {@code findByFirst} which could be completed to {@code findByFirstName} or {@code null} if it is a keyword or non-existent
 		 */
 		String lastWord,
 		/**

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodParser.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/providers/prefixsensitive/DataRepositoryMethodParser.java
@@ -30,9 +30,7 @@ class DataRepositoryMethodParser {
 
 	private static final Map<String, List<QueryPredicateKeywordInfo>> PREDICATE_KEYWORDS_GROUPED_BY_FIRST_WORD = QueryPredicateKeywordInfo.PREDICATE_KEYWORDS
 			.stream()
-			.collect(Collectors.groupingBy(info->{
-				return findFirstWord(info.keyword());
-			}));
+			.collect(Collectors.groupingBy(info -> findFirstWord(info.keyword())));
 
 	private final String prefix;
 	private final Map<String, List<DomainProperty>> propertiesGroupedByFirstWord;

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryCompletionProcessorTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryCompletionProcessorTest.java
@@ -138,9 +138,33 @@ public class DataRepositoryCompletionProcessorTest {
     }
 
     @Test
-    void findByComplexExpression() throws Exception {
+    void testFindByComplexExpression() throws Exception {
     	checkCompletions("findByResponsibleEmployee", "List<Customer> findByResponsibleEmployee(Employee responsibleEmployee);");
     	checkCompletions("findByResponsibleEmployee_SocialSecurityNumber", "List<Customer> findByResponsibleEmployee_SocialSecurityNumber(Long responsibleEmployee_SocialSecurityNumber);");
+    }
+
+    @Test
+    void testAppendKeywords() throws Exception {
+    	checkCompletions("findByFirstName",
+    			"findByFirstNameAnd",
+    			"findByFirstNameExists",
+    			"findByFirstNameIgnoreCase",
+    			"findByFirstNameIsLessThanEqual",
+    			"findByFirstNameOr",
+    			"findByFirstNameOrderBy");
+    }
+
+    @Test
+    void testAppendKeywordsWithPreviousKeyword() throws Exception {
+    	checkCompletions("findByFirstNameAnd",
+    			"findByFirstNameAndNot");
+    }
+
+    @Test
+    void testAppendKeywordsStartAlreadyPresent() throws Exception {
+    	checkCompletions("findByFirstNameA",
+    			"findByFirstNameAfter",
+    			"findByFirstNameAnd");
     }
 
 	private void checkCompletions(String alredyPresent, String... expectedCompletions) throws Exception {


### PR DESCRIPTION
This PR adds completions for predicate keywords in Spring Data repositories.

For example, it would suggest a completion `findByFirstNameAnd` when typing `findByFirstName`.

This is a follow-up to #981.

With this PR, it should now be possible to create most Spring JPA repository methods just with Content assist proposals (and adjusting the return type if wanted).