### PR TITLE
Switch to rewrite release versions for 4.18

### DIFF
--- a/headless-services/commons/pom.xml
+++ b/headless-services/commons/pom.xml
@@ -108,9 +108,9 @@
 		<commons-codec-version>1.13</commons-codec-version>
 
 		<!-- Rewrite specific properties -->
-		<rewrite-version>7.38.0-SNAPSHOT</rewrite-version>
-		<rewrite-spring-version>4.34.0-SNAPSHOT</rewrite-spring-version>
-		<rewrite-java-migration.version>1.18.0-SNAPSHOT</rewrite-java-migration.version>
+		<rewrite-version>7.37.3</rewrite-version>
+		<rewrite-spring-version>4.33.2</rewrite-spring-version>
+		<rewrite-java-migration.version>1.17.2</rewrite-java-migration.version>
 
 		<signing.skip>true</signing.skip>
 		<signing.alias>vmware</signing.alias>


### PR DESCRIPTION
Rewrite release versions to use for STS 4.18.0.

**rewrite-migrate-java** 1.17.2 isn't in Maven Central yet.

@martinlippert please merge this PR in your morning time if I won't push it tonight.