### PR TITLE
Fix JavaModelException with non-Java projects

### DIFF
--- a/eclipse-language-servers/org.springframework.tooling.boot.ls/src/org/springframework/tooling/boot/ls/BootProjectTester.java
+++ b/eclipse-language-servers/org.springframework.tooling.boot.ls/src/org/springframework/tooling/boot/ls/BootProjectTester.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.springsource.ide.eclipse.commons.internal.core.CorePlugin;
@@ -36,7 +37,7 @@ public class BootProjectTester extends PropertyTester {
 			}
 			if (resource != null) {
 				IProject project = resource.getProject();
-				if (project != null) {
+				if (project != null && JavaProject.hasJavaNature(project)) {
 					IJavaProject jp = JavaCore.create(project);
 					if (jp != null) {
 						return isProjectWithDependency(jp, "spring-boot");
@@ -52,7 +53,7 @@ public class BootProjectTester extends PropertyTester {
 			}
 			if (resource != null) {
 				IProject project = resource.getProject();
-				if (project != null) {
+				if (project != null && JavaProject.hasJavaNature(project)) {
 					IJavaProject jp = JavaCore.create(project);
 					if (jp != null) {
 						return isProjectWithDependency(jp, (String) args[0]);


### PR DESCRIPTION
Added a check that the JDT project uses to confirm the project is a Java project. JavaCore#create will return an object even if the project isn't a Java project and is therefore insufficient. Bring up the context menu on non Java projects to the see the JME logged without this fix (possibly other repercussions as well).