### PR TITLE
Fixes CCE: JavaNature cannot be cast to IJavaProject

### DIFF
--- a/eclipse-extensions/org.springframework.ide.eclipse.beans.ui.live/src/org/springframework/ide/eclipse/beans/ui/live/utils/JdtUtils.java
+++ b/eclipse-extensions/org.springframework.ide.eclipse.beans.ui.live/src/org/springframework/ide/eclipse/beans/ui/live/utils/JdtUtils.java
@@ -41,7 +41,7 @@ public class JdtUtils {
 		if (project.isAccessible()) {
 			try {
 				if (project.hasNature(JavaCore.NATURE_ID)) {
-					return (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+					return JavaCore.create(project);
 				}
 			} catch (CoreException e) {
 				LiveBeansUiPlugin.getDefault().getLog().log(new Status(IStatus.ERROR, LiveBeansUiPlugin.PLUGIN_ID,

--- a/eclipse-language-servers/org.springsource.ide.eclipse.commons.core/src/org/springsource/ide/eclipse/commons/core/JdtUtils.java
+++ b/eclipse-language-servers/org.springsource.ide.eclipse.commons.core/src/org/springsource/ide/eclipse/commons/core/JdtUtils.java
@@ -333,7 +333,7 @@ public class JdtUtils {
 		if (project.isAccessible()) {
 			try {
 				if (project.hasNature(JavaCore.NATURE_ID)) {
-					return (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+					return JavaCore.create(project);
 				}
 			}
 			catch (CoreException e) {


### PR DESCRIPTION
Due to [these changes](https://github.com/eclipse-jdt/eclipse.jdt.core/commit/4869388c3389ea51ff492a1129f1c442521c18da), this cast will now result in a ClassCastException.

It may not be too easy to reproduce this, though you can see from the code changes that a CCE would be expected. The following steps seem to trigger it.

1. Create a simple Java project using the Java project wizard.
2. Convert to faceted form using the context menu item.
3. Open the project's properties and go to the Project Facets property page, and add the Web Fragment facet. Apply the change. 
Usually at this point you should see the CCE in the error log. In some cases, adding the Dynamic Web Project facet would do it.

I realize this isn't a "Spring" use case, but it was one of the easiest ways I could find to trigger the code in `org.springsource.ide.eclipse.commons.core.JdtUtils`. Did not try to find a case that would trigger `org.springframework.ide.eclipse.beans.ui.live.utils.JdtUtils` though.