### PR TITLE
Fix missing proposal if the prefix starts with "/" for @ContextConfiguration

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/contextconfiguration/ContextConfigurationProcessor.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/contextconfiguration/ContextConfigurationProcessor.java
@@ -169,6 +169,7 @@ public class ContextConfigurationProcessor implements CompletionProvider {
     }
 
     private String[] findResources(IJavaProject project, String prefix) {
+        String filteredPrefix = prefix.replaceAll("^/+", "");
         String[] resources = IClasspathUtil.getClasspathResources(project.getClasspath()).stream()
                 .distinct()
                 .sorted(new Comparator<String>() {
@@ -178,7 +179,7 @@ public class ContextConfigurationProcessor implements CompletionProvider {
                     }
                 })
                 .map(r -> r.replaceAll("\\\\", "/"))
-                .filter(r -> ("classpath:" + r).contains(prefix))
+                .filter(r -> ("classpath:" + r).contains(filteredPrefix))
                 .toArray(String[]::new);
 
         return resources;

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/contextconfiguration/test/ContextConfigurationCompletionTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/contextconfiguration/test/ContextConfigurationCompletionTest.java
@@ -222,7 +222,39 @@ public class ContextConfigurationCompletionTest {
                 "@ContextConfiguration(locations=\"/a-random-resource-root.xml<*>\")");
     }
 
+    @Test
+    void testComplexResourceNameWithSlashPrefixAndWithLocationsAndParamNameCompletion() throws Exception {
+        prepareCase("@ContextConfiguration(\"onClass\")", "@ContextConfiguration(locations=\"/root.xml<*>\")");
 
+        assertClasspathCompletions(
+                "@ContextConfiguration(locations=\"/a-random-resource-root.xml<*>\")");
+    }
+
+    @Test
+    void testComplexResourceNameWithSlashPrefixAndWithValueAndParamNameCompletion() throws Exception {
+        prepareCase("@ContextConfiguration(\"onClass\")", "@ContextConfiguration(value=\"/root.xml<*>\")");
+
+        assertClasspathCompletions(
+                "@ContextConfiguration(value=\"/a-random-resource-root.xml<*>\")");
+    }
+
+    @Test
+    void testComplexResourceNameWithSlashPrefixAndParamNameCompletion() throws Exception {
+        prepareCase("@ContextConfiguration(\"onClass\")", "@ContextConfiguration(\"/root.xml<*>\")");
+
+        assertClasspathCompletions(
+                "@ContextConfiguration(\"/a-random-resource-root.xml<*>\")");
+    }
+
+    @Test
+    void testComplexResourceNameWithSlashPrefixAndDifferentParamNameCompletion() throws Exception {
+        prepareCase("@ContextConfiguration(\"onClass\")", "@ContextConfiguration(locations=\"/random<*>\")");
+
+        assertClasspathCompletions(
+                "@ContextConfiguration(locations=\"/a-random-resource-root.xml<*>\")",
+                "@ContextConfiguration(locations=\"/org/random-resource-org.xml<*>\")",
+                "@ContextConfiguration(locations=\"/org/test/random-resource-org-test.xml<*>\")");
+    }
 
     private void prepareCase(String selectedAnnotation, String annotationStatementBeforeTest) throws Exception {
         InputStream resource = this.getClass().getResourceAsStream("/test-projects/test-annotation-contextconfiguration/src/main/java/org/test/TestContextConfigurationCompletion.java");


### PR DESCRIPTION
Fixed missing proposal if the prefix starts with "/" for @ContextConfiguration annotations
Issue: #650 
