### PR TITLE
Correct typo from 'propeties' to 'properties'

### DIFF
--- a/eclipse-extensions/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/AbstractBootLaunchConfigurationDelegate.java
+++ b/eclipse-extensions/org.springframework.ide.eclipse.boot.launch/src/org/springframework/ide/eclipse/boot/launch/AbstractBootLaunchConfigurationDelegate.java
@@ -242,10 +242,10 @@ public abstract class AbstractBootLaunchConfigurationDelegate extends AdvancedJa
 	}
 
 	public static Properties getApplicationProperties(ILaunchConfiguration conf) {
-		String propetiesString = getRawApplicationProperties(conf);
+		String propertiesString = getRawApplicationProperties(conf);
 		Properties properties = new Properties();
 		try {
-			properties.load(new ByteArrayInputStream(propetiesString.getBytes()));
+			properties.load(new ByteArrayInputStream(propertiesString.getBytes()));
 		} catch (IOException e) {
 			Log.log(e);
 		}

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/properties/PropertiesToYamlCommandTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/properties/PropertiesToYamlCommandTest.java
@@ -91,7 +91,7 @@ public class PropertiesToYamlCommandTest {
 		Command cmd = new Command();
 		cmd.setCommand(PropertiesToYamlCommand.CMD_PROPS_TO_YAML);
 		cmd.setArguments(List.of(propsFilePath.toUri().toASCIIString(), yamlFilePath.toUri().toASCIIString(), replace));
-		cmd.setTitle("Convert .propeties to .yaml");
+		cmd.setTitle("Convert .properties to .yaml");
 		
 		ShowDocumentResult res = (ShowDocumentResult) harness.perform(cmd);
 		


### PR DESCRIPTION
Correct typo from 'propeties' to 'properties'.