### PR TITLE
[structural-view] Polish Modulith support

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModules.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModules.java
@@ -10,10 +10,12 @@
  *******************************************************************************/
 package org.springframework.ide.vscode.boot.java.commands;
 
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.ide.vscode.boot.java.stereotypes.StereotypeClassElement;
+import org.springframework.ide.vscode.boot.modulith.AppModule;
 import org.springframework.ide.vscode.boot.modulith.AppModules;
 
 public class ApplicationModules {
@@ -37,7 +39,10 @@ public class ApplicationModules {
 	}
 
 	public Stream<ApplicationModule> stream() {
-		return modules.stream().map(ApplicationModule::new);
+		
+		return modules.stream()
+				.sorted(Comparator.comparing(AppModule::displayName))
+				.map(ApplicationModule::new);
 	}
 
 }

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesStructureProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ApplicationModulesStructureProvider.java
@@ -32,6 +32,7 @@ public abstract class ApplicationModulesStructureProvider
 
 	@Override
 	public Collection<StereotypePackageElement> extractPackages(ApplicationModules application) {
+		
 		return application.stream()
 				.map(ApplicationModule::getBasePackage)
 				.map(pkg -> StructureViewUtil.findPackageNode(pkg, project, springIndex))

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/SpringIndexCommands.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/SpringIndexCommands.java
@@ -63,7 +63,7 @@ public class SpringIndexCommands {
 		
 		var catalog = stereotypeCatalogRegistry.getCatalogOf(project);
 		
-		if (ModulithService.isModulithDependentProject(project) && System.getProperty("structure-view-modulith-support") != null) {
+		if (ModulithService.isModulithDependentProject(project) && System.getProperty("disable-modulith-structure-view") == null) {
 			return new ModulithStructureView(catalog, springIndex, modulithService).createTree(project);
 		}
 		else {

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/StructureViewUtil.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/StructureViewUtil.java
@@ -145,7 +145,7 @@ public class StructureViewUtil {
 		}
 	}
 
-	private static final List<String> EXCLUSIONS = List.of("Application", "Properties", "Mappings");
+	private static final List<String> EXCLUSIONS = List.of("Application", "Properties", "Mappings", "Hints");
 
 	static Function<Stereotype, String> getStereotypeLabeler(StereotypeCatalog catalog) {
 

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/stereotypes/IndexBasedStereotypeFactory.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/stereotypes/IndexBasedStereotypeFactory.java
@@ -20,8 +20,9 @@ import org.jmolecules.stereotype.api.StereotypeFactory;
 import org.jmolecules.stereotype.api.Stereotypes;
 import org.jmolecules.stereotype.catalog.StereotypeDefinition.Assignment;
 import org.jmolecules.stereotype.catalog.StereotypeDefinition.Assignment.Type;
-import org.jmolecules.stereotype.catalog.StereotypeMatcher;
 import org.jmolecules.stereotype.catalog.support.AbstractStereotypeCatalog;
+import org.jmolecules.stereotype.catalog.support.StereotypeDetector.AnalysisLevel;
+import org.jmolecules.stereotype.catalog.support.StereotypeMatcher;
 import org.jmolecules.stereotype.support.StringBasedStereotype;
 import org.springframework.ide.vscode.boot.index.SpringMetamodelIndex;
 
@@ -55,26 +56,26 @@ public class IndexBasedStereotypeFactory implements StereotypeFactory<Stereotype
 
 	@Override
 	public Stereotypes fromPackage(StereotypePackageElement pkg) {
-		return new Stereotypes(fromAnnotatedElement(pkg));
+		return new Stereotypes(fromAnnotatedElement(pkg, AnalysisLevel.DIRECT));
 	}
 
 	@Override
 	public Stereotypes fromType(StereotypeClassElement type) {
-		return new Stereotypes(fromTypeInternal(type))
+		return new Stereotypes(fromTypeInternal(type, AnalysisLevel.DIRECT))
 				.and(fromPackage(findPackageFor(type)));
 	}
 
 	@Override
 	public Stereotypes fromMethod(StereotypeMethodElement method) {
-		return new Stereotypes(fromAnnotatedElement(method));
+		return new Stereotypes(fromAnnotatedElement(method, AnalysisLevel.DIRECT));
 	}
 	
-	private <T extends StereotypeAnnotatedElement> Collection<Stereotype> fromAnnotatedElement(StereotypeAnnotatedElement element) {
+	private <T extends StereotypeAnnotatedElement> Collection<Stereotype> fromAnnotatedElement(StereotypeAnnotatedElement element, AnalysisLevel level) {
 
 		var result = new ArrayList<Stereotype>();
 
 		if (element != null) {
-			result.addAll(catalog.getAnnotationBasedStereotypes(element, STEREOTYPE_MATCHER));
+			result.addAll(catalog.getAnnotationBasedStereotypes(element, level, STEREOTYPE_MATCHER));
 	
 	//		for (Annotation annotation : element.getAnnotations()) {
 	//			for (Class<?> type : fromAnnotation(annotation)) {
@@ -86,11 +87,11 @@ public class IndexBasedStereotypeFactory implements StereotypeFactory<Stereotype
 		return result;
 	}
 	
-	private Collection<Stereotype> fromTypeInternal(StereotypeClassElement type) {
+	private Collection<Stereotype> fromTypeInternal(StereotypeClassElement type, AnalysisLevel level) {
 
 		var result = new TreeSet<Stereotype>();
 
-		result.addAll(catalog.getTypeBasedStereotypes(type, STEREOTYPE_MATCHER));
+		result.addAll(catalog.getTypeBasedStereotypes(type, level, STEREOTYPE_MATCHER));
 
 //		if (type.isAnnotation()) {
 //
@@ -118,7 +119,7 @@ public class IndexBasedStereotypeFactory implements StereotypeFactory<Stereotype
 //		}
 //
 //		if (!type.isAnnotation()) {
-			result.addAll(fromAnnotatedElement(type));
+			result.addAll(fromAnnotatedElement(type, level));
 //		}
 
 		return result;

--- a/headless-services/spring-boot-language-server/src/main/resources/stereotype-defaults/spring-jmolecules-stereotypes.json
+++ b/headless-services/spring-boot-language-server/src/main/resources/stereotype-defaults/spring-jmolecules-stereotypes.json
@@ -39,7 +39,7 @@
 		},
 		"spring.RequestMapping" : {
 			"assignments" : [ "@org.springframework.web.bind.annotation.RequestMapping" ],
-			"displayName" : "Request mappings",
+			"displayName" : "Request Mappings",
 			"groups" : [ "spring.web" ]
 		},
 		"spring.Service" : {


### PR DESCRIPTION
- Application modules are now sorted alphabetically
- Enable Spring Modulith support by default, disable using -Ddisable-modulith-structure-view
- Prevent pluralization for (Runtime) Hints
- Fix capitalization in Request Mappings in fallback configuration
- Adapt to Steretypes API changes to support non-inherited stereotype assignments (for Heaxgonal Ports, etc.)
