### PR TITLE
Adapt to API changes in ad-hoc stereotype registration

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/JMoleculesStructureView.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/JMoleculesStructureView.java
@@ -55,7 +55,7 @@ public class JMoleculesStructureView {
 		};
 
 		// create json nodes to display the structure in a nice way
-		var jsonHandler = new JsonNodeHandler<StereotypePackageElement, Object>(labelProvider, consumer, springIndex);
+		var jsonHandler = new JsonNodeHandler<StereotypePackageElement, Object>(labelProvider, consumer, springIndex, catalog);
 		
 		// create the project tree and apply all the groupers from the project
 		// TODO: in the future, we need to trim this grouper arrays down to what is selected on the UI

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/JsonNodeHandler.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/JsonNodeHandler.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.jmolecules.stereotype.api.Stereotype;
+import org.jmolecules.stereotype.catalog.StereotypeCatalog;
 import org.jmolecules.stereotype.tooling.LabelProvider;
 import org.jmolecules.stereotype.tooling.MethodNodeContext;
 import org.jmolecules.stereotype.tooling.NodeContext;
@@ -58,19 +59,25 @@ public class JsonNodeHandler<A, C> implements NodeHandler<A, StereotypePackageEl
 	private final CachedSpringMetamodelIndex springIndex;
 
 	private Node current;
+	private StereotypeCatalog catalog;
 
 	public JsonNodeHandler(LabelProvider<A, StereotypePackageElement, StereotypeClassElement, StereotypeMethodElement, C> labels, BiConsumer<Node, C> customHandler,
-			CachedSpringMetamodelIndex springIndex) {
+			CachedSpringMetamodelIndex springIndex, StereotypeCatalog catalog) {
 		this.labels = labels;
 		this.springIndex = springIndex;
 		this.customHandler = customHandler;
 
 		this.root = new Node(null);
 		this.current = root;
+		this.catalog = catalog;
 	}
 	
 	@Override
 	public void handleStereotype(Stereotype stereotype, NodeContext context) {
+
+		// var definition = catalog.getDefinition(stereotype);
+		// var sources = definition.getSources();
+
 		addChild(node -> node
 			.withAttribute(TEXT, labels.getStereotypeLabel(stereotype))
 			.withAttribute(ICON, StereotypeIcons.getIcon(stereotype))

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ModulithStructureView.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/commands/ModulithStructureView.java
@@ -56,7 +56,7 @@ public class ModulithStructureView {
 		};
 
 		// create json nodes to display the structure in a nice way
-		var jsonHandler = new JsonNodeHandler<ApplicationModules, NamedInterfaceNode>(labelProvider, consumer, springIndex);
+		var jsonHandler = new JsonNodeHandler<ApplicationModules, NamedInterfaceNode>(labelProvider, consumer, springIndex, catalog);
 
 		// create the project tree and apply all the groupers from the project
 		// TODO: in the future, we need to trim this grouper arrays down to what is selected on the UI

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/stereotypes/IndexBasedStereotypeFactory.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/stereotypes/IndexBasedStereotypeFactory.java
@@ -18,7 +18,6 @@ import org.jmolecules.stereotype.api.Stereotype;
 import org.jmolecules.stereotype.api.StereotypeFactory;
 import org.jmolecules.stereotype.api.Stereotypes;
 import org.jmolecules.stereotype.catalog.StereotypeDefinition.Assignment;
-import org.jmolecules.stereotype.catalog.StereotypeDefinition.Assignment.Type;
 import org.jmolecules.stereotype.catalog.support.AbstractStereotypeCatalog;
 import org.jmolecules.stereotype.catalog.support.StereotypeDetector.AnalysisLevel;
 import org.jmolecules.stereotype.catalog.support.StereotypeMatcher;
@@ -133,13 +132,12 @@ public class IndexBasedStereotypeFactory implements StereotypeFactory<Stereotype
 	}
 	
 	private void registerStereotype(StereotypeDefinitionElement element) {
-		var stereotype = element.createStereotype();
 
-		String type = element.getType();
-		Type assignment = element.getAssignment();
-		
-		catalog.getOrRegister(stereotype, () -> Assignment.of(type, assignment))
-				.getStereotype();
+		var stereotype = element.createStereotype();
+		var type = element.getType();
+		var assignment = element.getAssignment();
+
+		catalog.getOrRegister(stereotype, Assignment.of(type, assignment), type).getStereotype();
 	}
 
 }


### PR DESCRIPTION
The registration now requires a source object to be handed into the definition creation to keep track of the definition's origin. JsonNodeHandler is now made aware of a StereotypeCatalog to be able to obtain the definition of a stereotype. That makes the source available in handleStereotype(…) which now needs actual handling of it.
