### PR TITLE
Quick fix for eclipse lsp process logging

### DIFF
--- a/eclipse-language-servers/org.springframework.tooling.ls.eclipse.commons/src/org/springframework/tooling/ls/eclipse/commons/STS4LanguageServerProcessStreamConnector.java
+++ b/eclipse-language-servers/org.springframework.tooling.ls.eclipse.commons/src/org/springframework/tooling/ls/eclipse/commons/STS4LanguageServerProcessStreamConnector.java
@@ -254,6 +254,11 @@ public abstract class STS4LanguageServerProcessStreamConnector extends ProcessSt
 		consoleJob.schedule();
 	}
 
+	@Override
+	public InputStream getErrorStream() {
+		return null;
+	}
+
 	private InputStream getLanguageServerLog() {
 		return super.getErrorStream();
 	}


### PR DESCRIPTION
Fixes #1742
Leave lsp4e `null` as error stream while our logging to file/console takes the stream from `getLanguageServerLog()`