### PR TITLE
Use Java text blocks for query conversion in Java 15+

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/QueryMethodCodeActionProvider.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/data/QueryMethodCodeActionProvider.java
@@ -80,7 +80,7 @@ public class QueryMethodCodeActionProvider implements JdtAstCodeActionProvider {
 							DataRepositoryAotMetadataCodeLensProvider
 									.getMetadata(repositoryMetadataService, project, binding)
 									.ifPresent(metadata -> metadata.findMethod(binding)
-											.map(method -> createCodeAction(binding, docURI, metadata, method, project))
+											.map(method -> createCodeAction(binding, docURI, metadata, method))
 											.ifPresent(collector::accept));
 						}
 					}
@@ -92,9 +92,9 @@ public class QueryMethodCodeActionProvider implements JdtAstCodeActionProvider {
 		};
 	}
 	
-	private CodeAction createCodeAction(IMethodBinding mb, URI docUri, DataRepositoryAotMetadata metadata, IDataRepositoryAotMethodMetadata method, IJavaProject project) {
+	private CodeAction createCodeAction(IMethodBinding mb, URI docUri, DataRepositoryAotMetadata metadata, IDataRepositoryAotMethodMetadata method) {
 		CodeAction ca = new CodeAction();
-		ca.setCommand(refactorings.createFixCommand(TITLE, DataRepositoryAotMetadataCodeLensProvider.createFixDescriptor(mb, docUri.toASCIIString(), metadata.module(), method, project)));
+		ca.setCommand(refactorings.createFixCommand(TITLE, DataRepositoryAotMetadataCodeLensProvider.createFixDescriptor(mb, docUri.toASCIIString(), metadata.module(), method)));
 		ca.setTitle(TITLE);
 		ca.setKind(CodeActionKind.Refactor);
 		return ca;

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryAotMetadataCodeLensProviderJdbcTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryAotMetadataCodeLensProviderJdbcTest.java
@@ -98,11 +98,8 @@ public class DataRepositoryAotMetadataCodeLensProviderJdbcTest {
 		assertEquals(2, cls.get(1).getCommand().getArguments().size());
 	}
 
-	/**
-	 * Verify that text blocks are generated when the query string contains quotes on Java 15 or above.
-	 */
 	@Test
-	void turnIntoQueryUsesTextBlockWhenQuotesPresentAndJava15OrAbove() throws Exception {
+	void turnIntoQueryUsesTextBlock() throws Exception {
 		Path filePath = Paths.get(testProject.getLocationUri())
 				.resolve("src/main/java/example/springdata/aot/CategoryRepository.java");
 
@@ -117,20 +114,7 @@ public class DataRepositoryAotMetadataCodeLensProviderJdbcTest {
 		String queryValue = extractValueFromAttributes(cls.get(0));
 		assertNotNull(queryValue, "Query value should not be null");
 
-		int javaVersion = 8;
-		String versionStr = testProject.getClasspath().getJre().version();
-		if (versionStr.startsWith("1.")) {
-			javaVersion = Integer.parseInt(versionStr.substring(2, 3));
-		} else {
-			javaVersion = Integer.parseInt(versionStr.split("\\.")[0]);
-		}
-
-		// JDBC query has quotes: SELECT "CATEGORY"."ID" ...
-		if (javaVersion >= 15) {
-			assertTrue(queryValue.startsWith("\"\"\""), "Text block must be used for Java >= 15 when quotes are present");
-		} else {
-			assertFalse(queryValue.startsWith("\"\"\""), "Text block must NOT be used for Java < 15");
-		}
+		assertTrue(queryValue.startsWith("\"\"\""), "Query should be generated as a text block");
 	}
 
 

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryAotMetadataCodeLensProviderJpaTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/DataRepositoryAotMetadataCodeLensProviderJpaTest.java
@@ -11,9 +11,6 @@
 package org.springframework.ide.vscode.boot.java.data.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -98,62 +95,4 @@ public class DataRepositoryAotMetadataCodeLensProviderJpaTest {
 		assertEquals(2, cls.get(1).getCommand().getArguments().size());
 	}
 
-	/**
-	 * Verify that text blocks are generated when the query string contains quotes on Java 15 or above.
-	 */
-	@Test
-	void turnIntoQueryUsesTextBlockWhenQuotesPresentAndJava15OrAbove() throws Exception {
-		Path filePath = Paths.get(testProject.getLocationUri())
-				.resolve("src/main/java/example/springdata/aot/UserRepository.java");
-
-		Editor editor = harness.newEditor(
-				LanguageId.JAVA,
-				new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8),
-				filePath.toUri().toASCIIString()
-		);
-
-		List<CodeLens> cls = editor.getCodeLenses("findUserByUsername", 1);
-		String queryValue = extractValueFromAttributes(cls.get(0));
-		assertNotNull(queryValue, "Query value should not be null");
-		System.out.println("Extracted query value: " + queryValue);
-
-		// JPA findUserByUsername query (SELECT u FROM users u ...) does not contain quotes.
-		boolean containsQuote = false;
-		
-		int javaVersion = 8;
-		String versionStr = testProject.getClasspath().getJre().version();
-		if (versionStr.startsWith("1.")) {
-			javaVersion = Integer.parseInt(versionStr.substring(2, 3));
-		} else {
-			javaVersion = Integer.parseInt(versionStr.split("\\.")[0]);
-		}
-
-		if (javaVersion >= 15 && containsQuote) {
-			assertTrue(queryValue.startsWith("\"\"\""), "Text block must be used for Java >= 15 when quotes are present");
-		} else {
-			assertFalse(queryValue.startsWith("\"\"\""), "Text block must NOT be used if Java < 15 or if quotes are missing");
-		}
-	}
-
-	private String extractValueFromAttributes(CodeLens codeLens) {
-		Object args = codeLens.getCommand().getArguments().get(1);
-		if (args instanceof com.google.gson.JsonObject) {
-			com.google.gson.JsonObject params = (com.google.gson.JsonObject) args;
-			if (params.has("parameters") && params.get("parameters").isJsonObject()) {
-				com.google.gson.JsonObject parameters = params.getAsJsonObject("parameters");
-				if (parameters.has("attributes") && parameters.get("attributes").isJsonArray()) {
-					com.google.gson.JsonArray attributes = parameters.getAsJsonArray("attributes");
-					for (com.google.gson.JsonElement element : attributes) {
-						if (element.isJsonObject()) {
-							com.google.gson.JsonObject attr = element.getAsJsonObject();
-							if (attr.has("name") && "value".equals(attr.get("name").getAsString())) {
-								return attr.get("value").getAsString();
-							}
-						}
-					}
-				}
-			}
-		}
-		return null;
-	}
 }

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/QueryMethodCodeActionProviderJpaTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/QueryMethodCodeActionProviderJpaTest.java
@@ -84,9 +84,11 @@ public class QueryMethodCodeActionProviderJpaTest {
 		assertEquals(RewriteRefactorings.REWRITE_RECIPE_QUICKFIX, cmd.getArguments().get(0));
 		WorkspaceEdit edit = refactorings.createEdit((JsonElement) cmd.getArguments().get(1)).get(5, TimeUnit.SECONDS);
 		TextDocumentEdit docEdit = edit.getDocumentChanges().get(0).getLeft();
+		String rawText = docEdit.getEdits().get(0).getNewText();
+
 		assertEquals(
-				"@Query(\"SELECT u FROM users u WHERE u.lastname LIKE :lastname ESCAPE '\\\\' ORDER BY u.firstname asc\")",
-				docEdit.getEdits().get(0).getNewText().trim());
+				"@Query(\"\"\"\nSELECT u FROM users u WHERE u.lastname LIKE :lastname ESCAPE '\\' ORDER BY u.firstname asc\n\"\"\")",
+				rawText.trim());
 		assertEquals(filePath.toUri().toASCIIString(), docEdit.getTextDocument().getUri());
 	}
 

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/QueryMethodCodeActionProviderMongoDbTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/data/test/QueryMethodCodeActionProviderMongoDbTest.java
@@ -84,22 +84,14 @@ public class QueryMethodCodeActionProviderMongoDbTest {
 		assertEquals(RewriteRefactorings.REWRITE_RECIPE_QUICKFIX, cmd.getArguments().get(0));
 		WorkspaceEdit edit = refactorings.createEdit((JsonElement) cmd.getArguments().get(1)).get(5, TimeUnit.SECONDS);
 		TextDocumentEdit docEdit = edit.getDocumentChanges().get(0).getLeft();
-		String rawNewText = docEdit.getEdits().get(0).getNewText().trim();
-		
-		if (rawNewText.startsWith("@Query(\"\"\"")) {
-			// Java 15+ behavior (Text Block)
-			assertEquals(
-					"@Query(\"\"\"\n" +
-					"{\"lastname\": /^\\Q?0\\E/}\n" +
-					"\"\"\")\n" +
-					"    Page<UserProjection> findUserByLastnameStartingWith(String lastname, Pageable page)",
-					rawNewText.replace("\r\n", "\n"));
-		} else {
-			// Java <15 behavior (String literal)
-			assertEquals(
-					"@Query(\"{\\\"lastname\\\": /^\\\\Q?0\\\\E/}\")",
-					rawNewText);
-		}
+		String rawText = docEdit.getEdits().get(0).getNewText().trim();
+
+		assertEquals(
+				"@Query(\"\"\"\n" +
+				"{\"lastname\": /^\\Q?0\\E/}\n" +
+				"\"\"\")\n"
+				+ "    Page<UserProjection> findUserByLastnameStartingWith(String lastname, Pageable page)",
+				rawText.replace("\r\n", "\n"));
 		assertEquals(filePath.toUri().toASCIIString(), docEdit.getTextDocument().getUri());
 	}
 


### PR DESCRIPTION
This PR addresses issue https://github.com/spring-projects/spring-tools/issues/1726

## Summary

* **JRE Version-Aware Query Generation**: Added logic to detect the project's Java version using `IJavaProject`.
* **Java 15+ Text Block Support**:
* If the project is running on Java 15 or higher and the query string contains quotes (`"`), the generator now uses Java Text Blocks (`"""`).
* For Java versions below 15 or queries without quotes, it falls back to the standard escaped string literal behavior.


* **Unified Implementation**:
* Refactored `createFixDescriptor` to be a static utility, ensuring consistent behavior between `CodeLens` and `CodeAction`.
* Applied changes across all supported modules: **JDBC, JPA, and MongoDB**.

## Resolved Issue

* **Improved Readability**: Eliminates excessive escaping (e.g., `\"`) in generated `@Query` annotations, particularly for JDBC SQL and MongoDB JSON queries.

## Discussion Points

* **Escaping in Text Blocks**: Currently, the raw query string is wrapped in `"""`. While standard SQL/JSON queries work fine, we may need to consider if additional escaping for internal `"""` sequences is necessary for edge cases.