### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    target-branch: "5.0.x"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This commit configured GitHub to keep GitHub actions up to the latest available version in the form of PRs.

It is specifically handy when pinning GitHub Actions with a SHA version since Dependabot will look up the hash for you. 

Incidentally, by adding this you'll automatically get the [forthcoming updates](https://github.com/spring-io/spring-release-actions/milestone/2?closed=1) for `announce-on-gchat`.

Let me know if there are any other active feature branches that should be monitored for GHA updates and I can add their configuration to this PR. We can also change the `labels` if there is a set of labels that makes more sense.