### PR TITLE
Fix 'occured' -> 'occurred' typos across language server and eclipse extensions

### DIFF
--- a/eclipse-extensions/org.springframework.ide.eclipse.maven.pom/src/org/springframework/ide/eclipse/maven/pom/XMLStructureCreator.java
+++ b/eclipse-extensions/org.springframework.ide.eclipse.maven.pom/src/org/springframework/ide/eclipse/maven/pom/XMLStructureCreator.java
@@ -109,7 +109,7 @@ public class XMLStructureCreator implements IStructureCreator {
 			Log.log(e);
 			return null;
 		} catch (Exception e) {
-			//				MessageDialog.openError(PomPlugin.getActiveWorkbenchShell(),"Error in XML parser","An error occured in the XML parser.\nNo structured compare can be shown");
+			//				MessageDialog.openError(PomPlugin.getActiveWorkbenchShell(),"Error in XML parser","An error occurred in the XML parser.\nNo structured compare can be shown");
 			Log.log(e);
 			return null;
 		}

--- a/eclipse-language-servers/org.springsource.ide.eclipse.commons.core/src/org/springsource/ide/eclipse/commons/core/ResourceProvider.java
+++ b/eclipse-language-servers/org.springsource.ide.eclipse.commons.core/src/org/springsource/ide/eclipse/commons/core/ResourceProvider.java
@@ -116,7 +116,7 @@ public class ResourceProvider {
 			} catch (BackingStoreException e) {
 				StatusHandler.log(new Status(IStatus.ERROR,
 						CorePlugin.PLUGIN_ID,
-						"Error occured while saving preferences", e));
+						"Error occurred while saving preferences", e));
 			}
 		}
 

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorLocal.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorLocal.java
@@ -187,7 +187,7 @@ public class SpringProcessConnectorLocal {
 				allStatusUpdates.get(5, TimeUnit.SECONDS);
 			}
 			catch (Exception e) {
-				log.info("timeout or problem occured while updating the status of the new processes");
+				log.info("timeout or problem occurred while updating the status of the new processes");
 			}
 		}
 	}

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorService.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/livehover/v2/SpringProcessConnectorService.java
@@ -172,7 +172,7 @@ public class SpringProcessConnectorService {
 				throw new CompletionException(e);
 			}
 		}, CompletableFuture.delayedExecutor(delay, unit, scheduler)).thenCompose(v -> refreshProcess(new SpringProcessParams(processKey, "", "", ""))).exceptionallyCompose(e -> {
-			log.info("problem occured during process connect", e);
+			log.info("problem occurred during process connect", e);
 
 			if (retryNo < maxRetryCount && isKnownProcessKey(processKey)) {
 				return scheduleConnect(progressTask, processKey, connector, retryDelayInSeconds, TimeUnit.SECONDS, retryNo + 1);
@@ -201,7 +201,7 @@ public class SpringProcessConnectorService {
 				progressTask.done();
 			}
 			catch (Exception e) {
-				log.info("problem occured during process disconnect", e);
+				log.info("problem occurred during process disconnect", e);
 
 				if (retryNo < maxRetryCount) {
 					scheduleDisconnect(progressTask, processKey, connector, retryDelayInSeconds, TimeUnit.SECONDS, retryNo + 1);
@@ -266,7 +266,7 @@ public class SpringProcessConnectorService {
 				throw new CompletionException(e);
 			}
 		}, CompletableFuture.delayedExecutor(delay, unit, scheduler)).exceptionallyCompose(e -> {
-			log.info("problem occured during process live data refresh", e);
+			log.info("problem occurred during process live data refresh", e);
 			
 			if (retryNo < maxRetryCount && isKnownProcessKey(processKey)) {
 				return scheduleRefresh(progressTask, springProcessParams, connector, retryDelayInSeconds, TimeUnit.SECONDS,
@@ -336,7 +336,7 @@ public class SpringProcessConnectorService {
 			}
 			catch (Exception e) {
 
-				log.info("problem occured during process live data refresh", e);
+				log.info("problem occurred during process live data refresh", e);
 
 				if (retryNo < maxRetryCount && isKnownProcessKey(processKey)) {
 					getLoggersData(progressTask, springProcessParams, connector, loggerData, retryDelayInSeconds, TimeUnit.SECONDS,
@@ -395,7 +395,7 @@ public class SpringProcessConnectorService {
 			}
 			catch (Exception e) {
 
-				log.info("problem occured during process live data refresh", e);
+				log.info("problem occurred during process live data refresh", e);
 
 				if (retryNo < maxRetryCount && isKnownProcessKey(processKey)) {
 					configureLogLevel(progressTask, springProcessParams, connector, retryDelayInSeconds, TimeUnit.SECONDS,

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/requestmapping/RequestMappingIndexer.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/requestmapping/RequestMappingIndexer.java
@@ -114,7 +114,7 @@ public class RequestMappingIndexer {
 						});
 
 			} catch (Exception e) {
-				log.error("problem occured while scanning for request mapping symbols from " + doc.getUri(), e);
+				log.error("problem occurred while scanning for request mapping symbols from " + doc.getUri(), e);
 			}
 		}
 	}


### PR DESCRIPTION
Fix 9 instances of `occured` → `occurred` across 5 Java files in Spring Tools. All are log messages and inline comments. No code or behavior change.

## Files

| File | Instances |
|------|-----------|
| `SpringProcessConnectorService.java` | 5 |
| `XMLStructureCreator.java` | 1 |
| `ResourceProvider.java` | 1 |
| `RequestMappingIndexer.java` | 1 |
| `SpringProcessConnectorLocal.java` | 1 |

## Testing

Comment/log-string-only change; no tests impacted.