### PR TITLE
Close FileOutputStream in extractIcon

### DIFF
--- a/eclipse-extensions/org.springframework.ide.eclipse.xml.namespaces/src/org/springframework/ide/eclipse/xml/namespaces/internal/ProjectClasspathNamespaceDefinitionResolver.java
+++ b/eclipse-extensions/org.springframework.ide.eclipse.xml.namespaces/src/org/springframework/ide/eclipse/xml/namespaces/internal/ProjectClasspathNamespaceDefinitionResolver.java
@@ -210,12 +210,13 @@ public class ProjectClasspathNamespaceDefinitionResolver implements INamespaceDe
 
 				try (
 					InputStream is = cls.getResourceAsStream(icon);
-					FileOutputStream os = new FileOutputStream(iconFile);
-				) {
-					IOUtils.copy(is, os);
-				}
+					try (FileOutputStream os = new FileOutputStream(iconFile)) {
+						) {
+						IOUtils.copy(is, os);
+						}
 				
-				return iconFile;
+						return iconFile;
+					}
 			}
 			catch (Exception e) {
 				SpringXmlNamespacesPlugin.log(


### PR DESCRIPTION
The code around line 213 in eclipse-extensions/org.springframework.ide.eclipse.xml.namespaces/src/org/springframework/ide/eclipse/xml/namespaces/internal/ProjectClasspathNamespaceDefinitionResolver.java looked like it might have an issue. The resource opened there can leak if extractIcon exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.