### PR TITLE
quickfix to adopt ApplicationModuleListener

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/app/JdtConfig.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/app/JdtConfig.java
@@ -39,6 +39,7 @@ import org.springframework.ide.vscode.boot.java.data.jpa.queries.JpqlSemanticTok
 import org.springframework.ide.vscode.boot.java.data.jpa.queries.JpqlSupportState;
 import org.springframework.ide.vscode.boot.java.data.jpa.queries.QueryJdtAstReconciler;
 import org.springframework.ide.vscode.boot.java.handlers.Reconciler;
+import org.springframework.ide.vscode.boot.java.reconcilers.ApplicationModuleListenerReconciler;
 import org.springframework.ide.vscode.boot.java.reconcilers.AddConfigurationIfBeansPresentReconciler;
 import org.springframework.ide.vscode.boot.java.reconcilers.AuthorizeHttpRequestsReconciler;
 import org.springframework.ide.vscode.boot.java.reconcilers.AutowiredFieldIntoConstructorParameterReconciler;
@@ -151,6 +152,10 @@ public class JdtConfig {
 	
 	@Bean ModulithTypeReferenceViolationReconciler modulithTypeReferenceViolationReconciler() {
 		return new ModulithTypeReferenceViolationReconciler();
+	}
+
+	@Bean ApplicationModuleListenerReconciler applicationModuleListenerReconciler(SimpleLanguageServer server) {
+		return new ApplicationModuleListenerReconciler(server.getQuickfixRegistry());
 	}
 	
 	@Bean NoRepoAnnotationReconciler noRepoAnnotationReconciler(SimpleLanguageServer server) {

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/Annotations.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/Annotations.java
@@ -43,6 +43,14 @@ public class Annotations {
 
 	public static final String CONTEXT_CONFIGURATION = "org.springframework.test.context.ContextConfiguration";
 	public static final String SCHEDULED = "org.springframework.scheduling.annotation.Scheduled";
+	public static final String ASYNC = "org.springframework.scheduling.annotation.Async";
+
+	public static final String TRANSACTIONAL = "org.springframework.transaction.annotation.Transactional";
+	public static final String TRANSACTIONAL_EVENT_LISTENER = "org.springframework.transaction.event.TransactionalEventListener";
+
+	// Modulith
+
+	public static final String APPLICATION_MODULE_LISTENER = "org.springframework.modulith.events.ApplicationModuleListener";
 	
 	// Beans
 	

--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/Boot3JavaProblemType.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/Boot3JavaProblemType.java
@@ -11,6 +11,7 @@
 package org.springframework.ide.vscode.boot.java;
 
 import static org.springframework.ide.vscode.commons.languageserver.reconcile.ProblemSeverity.ERROR;
+import static org.springframework.ide.vscode.commons.languageserver.reconcile.ProblemSeverity.WARNING;
 
 import java.util.List;
 
@@ -28,7 +29,10 @@ public enum Boot3JavaProblemType implements ProblemType {
 	
 	JAVA_TYPE_NOT_SUPPORTED(ERROR, "Type no supported as of Spring Boot 3", "Type not supported as of Spring Boot 3"),
 	FACTORIES_KEY_NOT_SUPPORTED(ERROR, "Spring factories key not supported", "Spring factories key not supported"),
-	MODULITH_TYPE_REF_VIOLATION(ERROR, "Modulith restricted type reference", "Modulith restricted type reference");
+	MODULITH_TYPE_REF_VIOLATION(ERROR, "Modulith restricted type reference", "Modulith restricted type reference"),
+	MODULITH_APPLICATION_MODULE_LISTENER(WARNING,
+			"Prefer @ApplicationModuleListener over @Async + @Transactional + @TransactionalEventListener",
+			"Use @ApplicationModuleListener");
 	
 	private final ProblemSeverity defaultSeverity;
 	private final String description;


### PR DESCRIPTION
ApplicationModuleListenerReconciler warns when a method in a Spring Modulith project is annotated with all three of @Async, @Transactional, and @TransactionalEventListener, suggesting they be replaced by the single composed @ApplicationModuleListener. A quick fix performs the replacement automatically, transferring any attributes from @TransactionalEventListener to the new annotation and cleaning up the imports. #1903