### PR TITLE
Do not flag overridden bean methods

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/reconcilers/BeanMethodNotPublicReconciler.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/reconcilers/BeanMethodNotPublicReconciler.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.springframework.ide.vscode.boot.java.reconcilers;
 
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,6 +34,7 @@ import org.springframework.ide.vscode.boot.java.jdt.refactoring.ChangeMethodVisi
 import org.springframework.ide.vscode.boot.java.jdt.refactoring.ChangeMethodVisibilityRefactoring.Visibility;
 import org.springframework.ide.vscode.boot.java.jdt.refactoring.JdtFixDescriptor;
 import org.springframework.ide.vscode.boot.java.jdt.refactoring.JdtRefactorings;
+import org.springframework.ide.vscode.boot.java.utils.ASTUtils;
 import org.springframework.ide.vscode.commons.Version;
 import org.springframework.ide.vscode.commons.java.IJavaProject;
 import org.springframework.ide.vscode.commons.java.SpringProjectUtil;
@@ -127,7 +128,7 @@ public class BeanMethodNotPublicReconciler implements JdtAstReconciler {
 	}
 
 	public static final boolean isNotOverridingPublicMethod(IMethodBinding methodBinding) {
-		return !isOverriding(methodBinding) && (methodBinding.getModifiers() & Modifier.PUBLIC) != 0;
+		return methodBinding != null && (methodBinding.getModifiers() & Modifier.PUBLIC) != 0 && !isOverriding(methodBinding);
 	}
 	
 	private void visitAnnotation(IJavaProject project, CompilationUnit cu, URI docUri, Annotation node,	IProblemCollector problemCollector, List<Integer> problemOffsets, List<ReconcileProblemImpl> problems) {
@@ -159,15 +160,18 @@ public class BeanMethodNotPublicReconciler implements JdtAstReconciler {
 	}
 	
 	private static final boolean isOverriding(IMethodBinding binding) {
-		try {
-			if (binding != null) {
-				Field f = binding.getClass().getDeclaredField("binding");
-				f.setAccessible(true);
-				org.eclipse.jdt.internal.compiler.lookup.MethodBinding  value = (org.eclipse.jdt.internal.compiler.lookup.MethodBinding) f.get(binding);
-				return value.isOverriding();
+		ITypeBinding declaringClass = binding.getDeclaringClass();
+		if (declaringClass == null) {
+			return false;
+		}
+		Iterator<ITypeBinding> hierarchy = ASTUtils.getHierarchyTypesBreadthFirstIterator(declaringClass);
+		hierarchy.next();
+		while (hierarchy.hasNext()) {
+			for (IMethodBinding inheritedMethod : hierarchy.next().getDeclaredMethods()) {
+				if (binding.overrides(inheritedMethod)) {
+					return true;
+				}
 			}
-		} catch (Exception e) {
-			log.error("", e);
 		}
 		return false;
 	}

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/reconcilers/test/SpringValidationBeanMethodNotPublicTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/reconcilers/test/SpringValidationBeanMethodNotPublicTest.java
@@ -123,4 +123,15 @@ public class SpringValidationBeanMethodNotPublicTest {
         List<Diagnostic> diagnostics = diagnosticsMessage.getDiagnostics();
         assertEquals(0, diagnostics.size());
     }
+
+    @Test
+    void testDoesNotFlagPublicBeanMethodThatOverridesInterfaceMethod() throws Exception {
+        String docUri = directory.toPath().resolve("src/main/java/org/test/BeanMethodNotPublicOverride.java").toUri().toString();
+
+        PublishDiagnosticsParams diagnosticsMessage = harness.getDiagnostics(docUri);
+        assertNotNull(diagnosticsMessage);
+
+        List<Diagnostic> diagnostics = diagnosticsMessage.getDiagnostics();
+        assertEquals(0, diagnostics.size());
+    }
 }

--- a/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-spring-validations/src/main/java/org/test/BeanMethodNotPublicOverride.java
+++ b/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-spring-validations/src/main/java/org/test/BeanMethodNotPublicOverride.java
@@ -1,0 +1,17 @@
+package org.test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.Validator;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class BeanMethodNotPublicOverride implements WebMvcConfigurer {
+
+	@Bean
+	@Override
+	public Validator getValidator() {
+		return null;
+	}
+
+}


### PR DESCRIPTION
Fixes gh-1911

This avoids reporting `JAVA_PUBLIC_BEAN_METHOD` when a public `@Bean` method overrides a method inherited from a superclass or implemented interface.

The reconciler keeps the existing override check and also walks the declaring type hierarchy with `ASTUtils.getHierarchyTypesBreadthFirstIterator(...)`, using JDT's public `IMethodBinding.overrides(...)` against inherited methods. This covers cases such as `WebMvcConfigurer#getValidator()`.

Tests:
- `./mvnw -pl spring-boot-language-server -am -Dtest=SpringValidationBeanMethodNotPublicTest,BeanMethodNotPublicReconcilerTest -Dsurefire.failIfNoSpecifiedTests=false test`