### PR TITLE
Avoid logging expected cache cancellation

### DIFF
--- a/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/CompilationUnitCache.java
+++ b/headless-services/spring-boot-language-server/src/main/java/org/springframework/ide/vscode/boot/java/utils/CompilationUnitCache.java
@@ -294,7 +294,7 @@ public final class CompilationUnitCache implements DocumentContentProvider {
 					}
 				})
 				.exceptionally(t -> {
-					if (!(t instanceof CancellationException)) {
+					if (!isCancellation(t)) {
 						logger.error("", t);
 					}
 					synchronized(CompilationUnitCache.this) {
@@ -304,6 +304,13 @@ public final class CompilationUnitCache implements DocumentContentProvider {
 				});
 		}
 		return cuFuture;
+	}
+
+	static boolean isCancellation(Throwable t) {
+		while (t instanceof CompletionException && t.getCause() != null) {
+			t = t.getCause();
+		}
+		return t instanceof CancellationException;
 	}
 
 	public static CompilationUnit parse2(char[] source, String docURI, String unitName, IJavaProject project) throws Exception {

--- a/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/utils/CompilationUnitCacheExceptionTest.java
+++ b/headless-services/spring-boot-language-server/src/test/java/org/springframework/ide/vscode/boot/java/utils/CompilationUnitCacheExceptionTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.springframework.ide.vscode.boot.java.utils;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for exception classification in the compilation unit cache.
+ *
+ * @author Pavel Zaitsev
+ */
+class CompilationUnitCacheExceptionTest {
+
+	@Test
+	void recognizesCancellationWrappedByCompletionStage() {
+		assertTrue(CompilationUnitCache.isCancellation(new CompletionException(new CancellationException())));
+	}
+
+	@Test
+	void doesNotTreatRealExceptionalCompletionAsCancellation() {
+		assertFalse(CompilationUnitCache.isCancellation(new CompletionException(new IllegalStateException())));
+	}
+
+}


### PR DESCRIPTION
Fixes #1777

Intentional compilation-unit cache invalidation cancels its cached future. The dependent completion stage receives that cancellation wrapped in a `CompletionException`, so the existing direct cancellation check logs an expected event as an error.

This change unwraps only `CompletionException` before applying the existing cancellation check. Other exceptional completions continue to be logged. Focused tests cover both wrapped cancellation and a wrapped real failure.

Validation: the repository `Check Pull Request` workflow passed on Linux, Windows, and macOS.