### PR TITLE
Use modern date formatting in XML validation fixture

### DIFF
--- a/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-xml-validations/src/main/java/u/t/r/HomeController.java
+++ b/headless-services/spring-boot-language-server/src/test/resources/test-projects/test-xml-validations/src/main/java/u/t/r/HomeController.java
@@ -1,7 +1,8 @@
 package u.t.r;
 
-import java.text.DateFormat;
-import java.util.Date;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.Locale;
 
 import org.slf4j.Logger;
@@ -26,10 +27,9 @@ public class HomeController {
 	public String home(Locale locale, Model model) {
 		logger.info("Welcome home! The client locale is {}.", locale);
 		
-		Date date = new Date();
-		DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, locale);
-		
-		String formattedDate = dateFormat.format(date);
+		String formattedDate = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
+				.withLocale(locale)
+				.format(ZonedDateTime.now());
 		
 		model.addAttribute("serverTime", formattedDate );
 		


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/10195366.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Replaced legacy DateFormat usage in the validation fixture with locale-aware java.time formatting.
